### PR TITLE
create "null" placeholder card

### DIFF
--- a/docs/bva/Card.md
+++ b/docs/bva/Card.md
@@ -2,17 +2,45 @@
 
 ## Method under test: `Card(CardType type)`
 
+### Step 1: Identify the input and output equivalence classes
+- Input: the card type used to construct the card
+- Output: the created card stores the provided type, or construction fails with an exception
+
+### Step 2: Choose the relevant data types from the BVA Catalog
+- Input: Cases
+- Output: Cases
+
+### Step 3: Select concrete values along the edges
+- Input cases: `EXPLODING_KITTEN`, `DEFUSE`, `PLACEHOLDER_CARD`, `null`
+- Output cases: created card stores the same type, or `NullPointerException` with message `type must not be null`
+
+### Step 4
+
 | ID | State of the system | Expected output | Implemented? |
 | --- | --- | --- | --- |
 | `CARD-CTOR-1` | Construct a card with `type = EXPLODING_KITTEN`. | Card is created successfully and stores `EXPLODING_KITTEN`. | :white_check_mark: |
 | `CARD-CTOR-2` | Construct a card with `type = DEFUSE`. | Card is created successfully and stores `DEFUSE`. | :white_check_mark: |
-| `CARD-CTOR-3` | Construct a card with `type = OTHER`. | Card is created successfully and stores `OTHER`. | :white_check_mark: |
+| `CARD-CTOR-3` | Construct a card with `type = PLACEHOLDER_CARD`. | Card is created successfully and stores `PLACEHOLDER_CARD`. | :x: |
 | `CARD-CTOR-4` | Construct a card with `type = null`. | Throw `NullPointerException` with message `type must not be null`. | :white_check_mark: |
 
 ## Method under test: `CardType getType()`
+
+### Step 1: Identify the input and output equivalence classes
+- Input: the state of the card after construction
+- Output: the stored card type returned by `getType()`
+
+### Step 2: Choose the relevant data types from the BVA Catalog
+- Input: Cases
+- Output: Cases
+
+### Step 3: Select concrete values along the edges
+- Input cases: card constructed with `EXPLODING_KITTEN`, `DEFUSE`, `PLACEHOLDER_CARD`
+- Output cases: returns the matching card type
+
+### Step 4
 
 | ID | State of the system | Expected output | Implemented? |
 | --- | --- | --- | --- |
 | `CARD-TYPE-1` | Card was constructed with `EXPLODING_KITTEN`. | Return `EXPLODING_KITTEN`. | :white_check_mark: |
 | `CARD-TYPE-2` | Card was constructed with `DEFUSE`. | Return `DEFUSE`. | :white_check_mark: |
-| `CARD-TYPE-3` | Card was constructed with `OTHER`. | Return `OTHER`. | :white_check_mark: |
+| `CARD-TYPE-3` | Card was constructed with `PLACEHOLDER_CARD`. | Return `PLACEHOLDER_CARD`. | :x: |

--- a/docs/bva/Card.md
+++ b/docs/bva/Card.md
@@ -2,45 +2,17 @@
 
 ## Method under test: `Card(CardType type)`
 
-### Step 1: Identify the input and output equivalence classes
-- Input: the card type used to construct the card
-- Output: the created card stores the provided type, or construction fails with an exception
-
-### Step 2: Choose the relevant data types from the BVA Catalog
-- Input: Cases
-- Output: Cases
-
-### Step 3: Select concrete values along the edges
-- Input cases: `EXPLODING_KITTEN`, `DEFUSE`, `PLACEHOLDER_CARD`, `null`
-- Output cases: created card stores the same type, or `NullPointerException` with message `type must not be null`
-
-### Step 4
-
 | ID | State of the system | Expected output | Implemented? |
 | --- | --- | --- | --- |
 | `CARD-CTOR-1` | Construct a card with `type = EXPLODING_KITTEN`. | Card is created successfully and stores `EXPLODING_KITTEN`. | :white_check_mark: |
 | `CARD-CTOR-2` | Construct a card with `type = DEFUSE`. | Card is created successfully and stores `DEFUSE`. | :white_check_mark: |
-| `CARD-CTOR-3` | Construct a card with `type = PLACEHOLDER_CARD`. | Card is created successfully and stores `PLACEHOLDER_CARD`. | :x: |
+| `CARD-CTOR-3` | Construct a card with `type = PLACEHOLDER_CARD`. | Card is created successfully and stores `PLACEHOLDER_CARD`. | :white_check_mark: |
 | `CARD-CTOR-4` | Construct a card with `type = null`. | Throw `NullPointerException` with message `type must not be null`. | :white_check_mark: |
 
 ## Method under test: `CardType getType()`
-
-### Step 1: Identify the input and output equivalence classes
-- Input: the state of the card after construction
-- Output: the stored card type returned by `getType()`
-
-### Step 2: Choose the relevant data types from the BVA Catalog
-- Input: Cases
-- Output: Cases
-
-### Step 3: Select concrete values along the edges
-- Input cases: card constructed with `EXPLODING_KITTEN`, `DEFUSE`, `PLACEHOLDER_CARD`
-- Output cases: returns the matching card type
-
-### Step 4
 
 | ID | State of the system | Expected output | Implemented? |
 | --- | --- | --- | --- |
 | `CARD-TYPE-1` | Card was constructed with `EXPLODING_KITTEN`. | Return `EXPLODING_KITTEN`. | :white_check_mark: |
 | `CARD-TYPE-2` | Card was constructed with `DEFUSE`. | Return `DEFUSE`. | :white_check_mark: |
-| `CARD-TYPE-3` | Card was constructed with `PLACEHOLDER_CARD`. | Return `PLACEHOLDER_CARD`. | :x: |
+| `CARD-TYPE-3` | Card was constructed with `PLACEHOLDER_CARD`. | Return `PLACEHOLDER_CARD`. | implemented in `CARD-CTOR-3` |

--- a/docs/design/model_layer.md
+++ b/docs/design/model_layer.md
@@ -47,7 +47,7 @@ CardType
 enum CardType {
     EXPLODING_KITTEN,
     DEFUSE,
-    OTHER
+    PLACEHOLDER_CARD
 }
 
 DiscardPile

--- a/src/main/java/domain/game/CardType.java
+++ b/src/main/java/domain/game/CardType.java
@@ -3,5 +3,5 @@ package domain.game;
 enum CardType {
     EXPLODING_KITTEN,
     DEFUSE,
-    OTHER
+    PLACEHOLDER_CARD
 }

--- a/src/test/java/domain/game/CardTest.java
+++ b/src/test/java/domain/game/CardTest.java
@@ -8,6 +8,13 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.api.Test;
 
 class CardTest {
+    @Test
+    void constructorStoresPlaceholderCardType() {
+        Card card = new Card(CardType.PLACEHOLDER_CARD);
+
+        assertEquals(CardType.PLACEHOLDER_CARD, card.getType());
+    }
+
     @ParameterizedTest
     @EnumSource(CardType.class)
     void constructorStoresProvidedCardType(CardType type) {

--- a/src/test/java/domain/game/DeckTest.java
+++ b/src/test/java/domain/game/DeckTest.java
@@ -120,7 +120,7 @@ class DeckTest {
 
     @Test
     void removeCardsByTypeReturnsEmptyListWhenTypeIsAbsent() {
-        Card firstCard = createCardWithType(CardType.OTHER);
+        Card firstCard = createCardWithType(CardType.PLACEHOLDER_CARD);
         Card secondCard = createCardWithType(CardType.DEFUSE);
         Deck deck = new Deck(List.of(firstCard, secondCard));
 
@@ -134,7 +134,7 @@ class DeckTest {
     @Test
     void removeCardsByTypeRemovesMatchingCardsOnly() {
         Card firstCard = createCardWithType(CardType.DEFUSE);
-        Card secondCard = createCardWithType(CardType.OTHER);
+        Card secondCard = createCardWithType(CardType.PLACEHOLDER_CARD);
         Card thirdCard = createCardWithType(CardType.DEFUSE);
         Deck deck = new Deck(List.of(firstCard, secondCard, thirdCard));
 
@@ -147,7 +147,7 @@ class DeckTest {
 
     @Test
     void removeCardsByTypeRejectsNullType() {
-        Card card = createCardWithType(CardType.OTHER);
+        Card card = createCardWithType(CardType.PLACEHOLDER_CARD);
         Deck deck = new Deck(List.of(card));
 
         IllegalArgumentException exception =

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -148,7 +148,7 @@ class GameTest {
             cards.add(createCardWithType(CardType.DEFUSE));
         }
         for (int count = 0; count < others; count++) {
-            cards.add(createCardWithType(CardType.OTHER));
+            cards.add(createCardWithType(CardType.PLACEHOLDER_CARD));
         }
         return new Deck(cards);
     }


### PR DESCRIPTION
PLACEHOLDER_CARD (formerly OTHER, but renamed to be more clear), is basically a temporary bridge between "we need a full deck now" and "we haven't implemented all the card types yet"

PLACEHOLDER_CARD will be created, shuffled, dealt, counted, drawn, removed, and discarded just like other cards, but it should not have any special effect. Later real card types replace placeholders