### PR TITLE
Wip/mutation coverage

### DIFF
--- a/docs/bva/Game.md
+++ b/docs/bva/Game.md
@@ -19,6 +19,7 @@
 | `GAME-SETUP-6` | Valid player count but deck contains fewer defuses than players. | Throw `IllegalStateException` with message `deck must contain at least one defuse per player`. | :white_check_mark: |
 | `GAME-SETUP-7` | Valid player count but deck contains fewer exploding kittens than `playerCount - 1`. | Throw `IllegalStateException` with message `deck must contain enough exploding kittens for setup`. | :white_check_mark: |
 | `GAME-SETUP-8` | Valid player count but deck contains fewer than `5 * playerCount` non-special cards. | Throw `IllegalStateException` with message `deck must contain enough non-special cards to deal opening hands`. | :white_check_mark: |
+| `GAME-SETUP-9` | Valid 2-player game uses a real `Deck` with injected `Random`. | `setupGame` invokes the setup shuffle before dealing and the final shuffle after reinserting Defuses and Exploding Kittens, without assuming either shuffle must change deck order. | :white_check_mark: |
 
 ## Method under test: `public List<Player> getPlayers()`
 

--- a/docs/bva/Game.md
+++ b/docs/bva/Game.md
@@ -41,6 +41,7 @@
 | ID | State of the system | Expected output | Implemented? |
 | --- | --- | --- | --- |
 | `GAME-ELIMINATE-1` | Game has 3 active players; eliminated player is active. | Remove that player, keep the other 2 players active, and `isWon()` returns `false`. | :white_check_mark: |
+| `GAME-ELIMINATE-2` | Game has 3 active players, the current player is the last player in turn order, and that current player is eliminated. | Remove that player and wrap the current player pointer to the first remaining player. | :white_check_mark: |
 
 ## Method under test: `boolean isWon()`
 

--- a/src/main/java/domain/game/ExplodingKittenCardController.java
+++ b/src/main/java/domain/game/ExplodingKittenCardController.java
@@ -47,4 +47,6 @@ public final class ExplodingKittenCardController {
         }
         return -1;
     }
+
+
 }

--- a/src/main/java/domain/game/Game.java
+++ b/src/main/java/domain/game/Game.java
@@ -148,7 +148,12 @@ public class Game {
         players.remove(player);
     }
 
+    public void advanceTurn() {
+        currentPlayerIndex = (currentPlayerIndex + 1) % players.size();
+    }
+
     boolean isWon() {
         return players.size() == 1;
     }
+
 }

--- a/src/main/java/domain/game/Game.java
+++ b/src/main/java/domain/game/Game.java
@@ -148,6 +148,9 @@ public class Game {
     }
     void eliminatePlayer(Player player) {
         players.remove(player);
+        if (currentPlayerIndex >= players.size()) {
+            currentPlayerIndex = 0;
+        }
     }
 
     public void advanceTurn() {

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -57,9 +57,9 @@ public class GameController {
 
             SkipCardController skipCardController = new SkipCardController(model.getDiscardPile());
 
-            boolean skipped = skipCardController.play(currentPlayer, cardIndex);
+            skipCardController.play(currentPlayer, cardIndex);
             view.displayMessage(SKIP_PLAYED);
-            return skipped;
+            return true;
         } catch (IllegalArgumentException | IndexOutOfBoundsException e) {
             view.displayError(e.getMessage());
             return false;

--- a/src/test/java/domain/game/ExplodingKittenCardControllerTest.java
+++ b/src/test/java/domain/game/ExplodingKittenCardControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -144,5 +145,24 @@ class ExplodingKittenCardControllerTest {
         assertEquals(List.of(defuse), player.getHandSnapshot());
         assertEquals(List.of(drawPileCard), drawPile.snapshot());
         assertEquals(List.of(discardedCard), discardPile.snapshot());
+    }
+
+    @Test
+    void play_DefuseNotAtFirstIndex_DefusesKitten() {
+        Deck drawPile = new Deck(new ArrayList<>());
+        DiscardPile discardPile = new DiscardPile();
+        ExplodingKittenCardController controller =
+                new ExplodingKittenCardController(drawPile, discardPile);
+
+        Player player = new Player("Avery");
+        player.addCard(new Card(CardType.PLACEHOLDER_CARD));
+        player.addCard(new Card(CardType.DEFUSE));           // add defuse at index 1
+
+        Card explodingKitten = new Card(CardType.EXPLODING_KITTEN);
+        boolean result = controller.play(player, explodingKitten);
+
+        assertTrue(result);
+        assertEquals(1, player.getHandSize()); // placeholder remains after defuse is removed
+        assertEquals(CardType.PLACEHOLDER_CARD, player.getHandSnapshot().get(0).getType());
     }
 }

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -231,6 +231,7 @@ public class GameControllerTest {
 
         assertEquals(1, game.getDrawPile().size());
 
+
         // record expected view call
         mockView.displayCardDrawn(EasyMock.anyObject(Card.class));
         EasyMock.expectLastCall().once();
@@ -241,6 +242,7 @@ public class GameControllerTest {
 
         assertEquals(expectedCard, result);
         assertEquals(0, game.getDrawPile().size());
+        assertEquals(7, game.getCurrentPlayer().getHandSize());
 
         verify(mockView);
     }

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -212,6 +212,15 @@ class GameTest {
 
         assertEquals(0, game.getCurrentPlayerIndex());
     }
+    @Test
+    void getCurrentPlayerIndex_AfterSetupAndOneRound_ReturnsOne() {
+        Game game = new Game(createDeck(3, 3, 12));
+        game.setupGame(List.of("Avery", "Jordan"));
+        game.advanceTurn();
+
+        assertNotEquals(0, game.getCurrentPlayerIndex());
+    }
+
 
     private void assertPlayersHaveOpeningHands(List<Player> players) {
         for (Player player : players) {

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -164,6 +164,21 @@ class GameTest {
     }
 
     @Test
+    void eliminateCurrentLastPlayer_WrapsCurrentPlayerToFirstRemainingPlayer() {
+        Game game = new Game(createDeck(3, 3, 15));
+        game.setupGame(List.of("Avery", "Jordan", "Casey"));
+        game.advanceTurn();
+        game.advanceTurn();
+        Player eliminatedPlayer = game.getCurrentPlayer();
+
+        game.eliminatePlayer(eliminatedPlayer);
+
+        assertFalse(game.getPlayers().contains(eliminatedPlayer));
+        assertEquals("Avery", game.getCurrentPlayer().getName());
+        assertEquals(0, game.getCurrentPlayerIndex());
+    }
+
+    @Test
     void setupGame_UsesInjectedRandomForBothSetupShuffles() {
         Random random = EasyMock.createMock(Random.class);
         expectShuffle(random, 10);

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -5,7 +5,11 @@ import java.util.List;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class GameTest {
     @Test

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -187,7 +187,19 @@ class GameTest {
         assertEquals(2, game.getPlayers().size());
     }
 
+    @Test
+    void setupGame_CalledTwice_ClearsPlayers() {
+        //initialize deck big enough for back to back game setups
+        Game game = new Game(createDeck(6, 6, 24));
 
+        game.setupGame(List.of("Avery", "Jordan"));
+        List<Player> playerOne = game.getPlayers();
+        game.setupGame(List.of("Morgan", "Kate"));
+        List<Player> playerTwo = game.getPlayers();
+
+        assertEquals(2, game.getPlayers().size());
+        assertNotEquals(playerOne, playerTwo);
+    }
 
 
     private void assertPlayersHaveOpeningHands(List<Player> players) {

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -221,6 +221,17 @@ class GameTest {
         assertNotEquals(0, game.getCurrentPlayerIndex());
     }
 
+    @Test
+    void advanceTurn_WrapsAroundToFirstPlayer() {
+        Game game = new Game(createDeck(3, 3, 12));
+        game.setupGame(List.of("Avery", "Jordan"));
+
+        game.advanceTurn(); // index = 1
+        game.advanceTurn(); // index should wrap to 0
+
+        assertEquals("Avery", game.getCurrentPlayer().getName());
+    }
+
 
     private void assertPlayersHaveOpeningHands(List<Player> players) {
         for (Player player : players) {

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -205,6 +205,13 @@ class GameTest {
         assertNotEquals(playerOne, playerTwo);
     }
 
+    @Test
+    void getCurrentPlayerIndex_AfterSetup_ReturnsZero() {
+        Game game = new Game(createDeck(3, 3, 12));
+        game.setupGame(List.of("Avery", "Jordan"));
+
+        assertEquals(0, game.getCurrentPlayerIndex());
+    }
 
     private void assertPlayersHaveOpeningHands(List<Player> players) {
         for (Player player : players) {

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -1,14 +1,11 @@
 package domain.game;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class GameTest {
     @Test
@@ -160,6 +157,38 @@ class GameTest {
         assertEquals("Casey", game.getPlayers().get(1).getName());
         assertFalse(game.isWon());
     }
+
+    /*@Test
+    void setupGame_ShuffleIsCalledTwice() {
+        Deck mockDeck = EasyMock.createMock(Deck.class);
+        EasyMock.expect(mockDeck.countCardsOfType(CardType.EXPLODING_KITTEN)).andReturn(1L);
+        EasyMock.expect(mockDeck.countCardsOfType(CardType.DEFUSE)).andReturn(2L);
+        EasyMock.expect(mockDeck.size()).andReturn(20);
+        EasyMock.expect(mockDeck.removeCardsByType(CardType.EXPLODING_KITTEN));
+        EasyMock.expect(mockDeck.removeCardsByType(CardType.DEFUSE));
+
+        mockDeck.shuffle();
+        EasyMock.expectLastCall().times(2);
+
+        EasyMock.replay(mockDeck);
+        Game game = new Game(mockDeck);
+        game.setupGame(List.of("Avery", "Jordan"));
+        EasyMock.verify(mockDeck);
+    }*/
+
+    @Test
+    void setupGame_CalledTwice_DoesNotDuplicatePlayers() {
+        //initialize deck big enough for back to back game setups
+        Game game = new Game(createDeck(6, 6, 24));
+
+        game.setupGame(List.of("Avery", "Jordan"));
+        game.setupGame(List.of("Avery", "Jordan"));
+
+        assertEquals(2, game.getPlayers().size());
+    }
+
+
+
 
     private void assertPlayersHaveOpeningHands(List<Player> players) {
         for (Player player : players) {

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -2,6 +2,7 @@ package domain.game;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
@@ -162,23 +163,18 @@ class GameTest {
         assertFalse(game.isWon());
     }
 
-    /*@Test
-    void setupGame_ShuffleIsCalledTwice() {
-        Deck mockDeck = EasyMock.createMock(Deck.class);
-        EasyMock.expect(mockDeck.countCardsOfType(CardType.EXPLODING_KITTEN)).andReturn(1L);
-        EasyMock.expect(mockDeck.countCardsOfType(CardType.DEFUSE)).andReturn(2L);
-        EasyMock.expect(mockDeck.size()).andReturn(20);
-        EasyMock.expect(mockDeck.removeCardsByType(CardType.EXPLODING_KITTEN));
-        EasyMock.expect(mockDeck.removeCardsByType(CardType.DEFUSE));
+    @Test
+    void setupGame_UsesInjectedRandomForBothSetupShuffles() {
+        Random random = EasyMock.createMock(Random.class);
+        expectShuffle(random, 10);
+        expectShuffle(random, 2);
+        EasyMock.replay(random);
+        Game game = new Game(createDeck(3, 3, 10, random));
 
-        mockDeck.shuffle();
-        EasyMock.expectLastCall().times(2);
-
-        EasyMock.replay(mockDeck);
-        Game game = new Game(mockDeck);
         game.setupGame(List.of("Avery", "Jordan"));
-        EasyMock.verify(mockDeck);
-    }*/
+
+        EasyMock.verify(random);
+    }
 
     @Test
     void setupGame_CalledTwice_DoesNotDuplicatePlayers() {
@@ -250,6 +246,14 @@ class GameTest {
     }
 
     private Deck createDeck(int explodingKittens, int defuses, int others) {
+        return new Deck(createCards(explodingKittens, defuses, others));
+    }
+
+    private Deck createDeck(int explodingKittens, int defuses, int others, Random random) {
+        return new Deck(createCards(explodingKittens, defuses, others), random);
+    }
+
+    private List<Card> createCards(int explodingKittens, int defuses, int others) {
         List<Card> cards = new ArrayList<>();
         for (int count = 0; count < explodingKittens; count++) {
             cards.add(createCardWithType(CardType.EXPLODING_KITTEN));
@@ -260,7 +264,13 @@ class GameTest {
         for (int count = 0; count < others; count++) {
             cards.add(createCardWithType(CardType.PLACEHOLDER_CARD));
         }
-        return new Deck(cards);
+        return cards;
+    }
+
+    private void expectShuffle(Random random, int deckSize) {
+        for (int bound = deckSize; bound > 1; bound--) {
+            EasyMock.expect(random.nextInt(bound)).andReturn(0);
+        }
     }
 
     private Card createCardWithType(CardType type) {

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -232,6 +232,15 @@ class GameTest {
         assertEquals("Avery", game.getCurrentPlayer().getName());
     }
 
+    @Test
+    void advanceTurn_ThreePlayers_CurrentPlayerIsSecond() {
+        Game game = new Game(createDeck(4, 4, 20));
+        game.setupGame(List.of("Avery", "Jordan", "Casey"));
+
+        game.advanceTurn();
+
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+    }
 
     private void assertPlayersHaveOpeningHands(List<Player> players) {
         for (Player player : players) {


### PR DESCRIPTION
This PR adds mutation and coverage tests for `Game.java`, `GameController.java`, and `Player.java`, implements `advanceTurn()` in `Game`

**What's done**

- Added tests to kill mutations in `Game.java`, `GameController.java`, `Player.java`, and `ExplodingKittenCardController.java`
- Implemented `advanceTurn()` in `Game.java` and added tests for turn advancement and wraparound
- Fixed `players.clear()` mutation with a double `setupGame` test
- Killed the `drawPile.shuffle()` removal mutations in `Game.setupGame()` by testing through a real `Deck` with injected `Random` (avoided assuming that shuffle() must change deck order)


**Left for discussion**

**1. RESOLVED: `Deck` being `final` and shuffle mutations**
Lines 65 and 69 in `Game.java` have survived mutations where `drawPile.shuffle()` is removed. These can't be killed because `Deck` is `final` and can't be mocked. To get around this, we could assume that `drawPile.shuffle()` shouldn't return the same deck order. Using the Random class means technically you could get the exact same deck. with the assumption, a test that makes sure the order of the deck is different would be sufficient. 

**2. RESOLVED (will change SkipCardController later when we implement full skip rules): `SkipCardController.play()` equivalent mutation**
The mutation `replaced boolean return with true` on line 62 of `GameController.java` is equivalent — `SkipCardController.play()` always returns `true` by design, so the mutant and real code are identical. Killing this would require a design change to `SkipCardController`.

**3. RESOLVED `advanceTurn()` subtraction mutation**
The mutation replacing `+` with `-` in `advanceTurn()` is still surviving. Open to discussion on the best approach to kill it.


