### PR TITLE
Complete turn behavior

### DIFF
--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -67,9 +67,9 @@ private Game game;
 ## Method under test: `completeTurn(List<Integer> cardIndexes)`
 | Step 1                              | Step 2     | Step 3                                  |
 |-------------------------------------|------------|-----------------------------------------|
-| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li></ul> |
-| Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li></ul> |
-| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li></ul> |
+| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li></ul> |
+| Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li><li>Two cards available for See the Future</li></ul> |
+| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li></ul> |
 
 - **TC2: completeTurn_NoCardsPlayed_DisplaysHandThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[]`, and the draw pile top card is `PLACEHOLDER_CARD`.
@@ -78,3 +78,7 @@ private Game game;
 - **TC3: completeTurn_SkipPlayed_DisplaysHandThenEndsWithoutDrawing** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0]`, card index `0` is `SKIP`, and the draw pile has one card.
   - **Expected output**: Displays `Sophie`'s hand, plays and discards `SKIP`, leaves the draw pile unchanged, and advances current player to `Jordan`.
+
+- **TC4: completeTurn_SeeFuturePlayed_DisplaysFutureThenDrawsAndAdvances** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0]`, card index `0` is `SEE_THE_FUTURE`, and the draw pile has two cards.
+  - **Expected output**: Displays `Sophie`'s hand, plays and discards `SEE_THE_FUTURE`, displays the top two draw pile cards, draws the top card, and advances current player to `Jordan`.

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -67,9 +67,9 @@ private Game game;
 ## Method under test: `completeTurn(List<Integer> cardIndexes)`
 | Step 1                              | Step 2     | Step 3                                  |
 |-------------------------------------|------------|-----------------------------------------|
-| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li></ul> |
-| Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li><li>Two cards available for See the Future</li></ul> |
-| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li></ul> |
+| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li></ul> |
+| Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li><li>Two cards available for See the Future</li><li>Two cards available to shuffle before drawing</li></ul> |
+| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li><li>Shuffles the draw pile, then draws when Shuffle is played</li></ul> |
 
 - **TC2: completeTurn_NoCardsPlayed_DisplaysHandThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[]`, and the draw pile top card is `PLACEHOLDER_CARD`.
@@ -86,3 +86,7 @@ private Game game;
 - **TC5: completeTurn_TwoSeeFutureCardsPlayed_DisplaysBothThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0, 0]`, both selected cards are `SEE_THE_FUTURE`, and the draw pile has two cards.
   - **Expected output**: Displays `Sophie`'s hand, plays and discards both `SEE_THE_FUTURE` cards, displays the top two draw pile cards after each play, draws the top card, and advances current player to `Jordan`.
+
+- **TC6: completeTurn_ShufflePlayed_ShufflesThenDrawsAndAdvances** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0]`, card index `0` is `SHUFFLE`, and the draw pile has two cards with injected deterministic randomness.
+  - **Expected output**: Displays `Sophie`'s hand, plays and discards `SHUFFLE`, shuffles the draw pile using the injected random source, draws the new top card, and advances current player to `Jordan`.

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -53,4 +53,13 @@ private Game game;
 | `GCMaxPlayer `          | max number of players                              | None: game starts          , gameStarted = True              | :x_mark:     |
 | `GCMultiPlayer `        | duplicate player  names                            | Confirm and rename players exception , gameStarted = False   | :x_mark:     |
 
+## Method under test: `startTurn()`
+| Step 1                       | Step 2     | Step 3                                        |
+|------------------------------|------------|-----------------------------------------------|
+| Internal state: current player | Object     | Values: <ul><li>Player named `Sophie`</li></ul> |
+| Internal state: current hand | Collection | Values: <ul><li>More than one card</li></ul> |
+| Output                       | UI Message | Values: <ul><li>Displays the current player's hand</li></ul> |
 
+- **TC1: startTurn_DisplaysCurrentPlayerHand** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie` with [`SKIP`, `BEARD_CAT`] in hand.
+  - **Expected output**: Calls the view to display `Sophie`'s hand with those cards.

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -67,7 +67,7 @@ private Game game;
 ## Method under test: `completeTurn(List<Integer> cardIndexes)`
 | Step 1                              | Step 2     | Step 3                                  |
 |-------------------------------------|------------|-----------------------------------------|
-| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li><li>Selected See the Future followed by selected Skip</li><li>Selected Skip followed by another card</li><li>One selected unplayable card index</li><li>One selected index equal to hand size</li></ul> |
+| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li><li>Selected See the Future followed by selected Skip</li><li>Selected Skip followed by another card</li><li>One selected unplayable card index</li><li>One selected index equal to hand size</li><li>One negative selected index</li></ul> |
 | Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li><li>Two cards available for See the Future</li><li>Two cards available to shuffle before drawing</li></ul> |
 | Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li><li>Shuffles the draw pile, then draws when Shuffle is played</li><li>Ends turn without drawing when Skip is played after a non-ending card</li><li>Ignores later selected cards after Skip ends the turn</li><li>Displays error for an unplayable selected card</li><li>Displays error for an out-of-bounds selected index</li></ul> |
 
@@ -105,4 +105,8 @@ private Game game;
 
 - **TC10: completeTurn_IndexEqualsHandSize_DisplaysErrorThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card index is equal to `Sophie`'s hand size, and the draw pile top card is `PLACEHOLDER_CARD`.
+  - **Expected output**: Displays `Sophie`'s hand, displays an out-of-bounds error, keeps the hand's existing card, draws the top card, and advances current player to `Jordan`.
+
+- **TC11: completeTurn_NegativeIndex_DisplaysErrorThenDrawsAndAdvances** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card index is `-1`, and the draw pile top card is `PLACEHOLDER_CARD`.
   - **Expected output**: Displays `Sophie`'s hand, displays an out-of-bounds error, keeps the hand's existing card, draws the top card, and advances current player to `Jordan`.

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -63,3 +63,14 @@ private Game game;
 - **TC1: startTurn_DisplaysCurrentPlayerHand** (:white_check_mark:)
   - **State of system**: Current player is `Sophie` with [`SKIP`, `BEARD_CAT`] in hand.
   - **Expected output**: Calls the view to display `Sophie`'s hand with those cards.
+
+## Method under test: `completeTurn(List<Integer> cardIndexes)`
+| Step 1                              | Step 2     | Step 3                                  |
+|-------------------------------------|------------|-----------------------------------------|
+| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li></ul>   |
+| Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li></ul> |
+| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li></ul> |
+
+- **TC2: completeTurn_NoCardsPlayed_DisplaysHandThenDrawsAndAdvances** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[]`, and the draw pile top card is `PLACEHOLDER_CARD`.
+  - **Expected output**: Displays `Sophie`'s hand, draws the `PLACEHOLDER_CARD`, adds it to `Sophie`'s hand, and advances current player to `Jordan`.

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -67,10 +67,14 @@ private Game game;
 ## Method under test: `completeTurn(List<Integer> cardIndexes)`
 | Step 1                              | Step 2     | Step 3                                  |
 |-------------------------------------|------------|-----------------------------------------|
-| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li></ul>   |
+| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li></ul> |
 | Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li></ul> |
-| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li></ul> |
+| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li></ul> |
 
 - **TC2: completeTurn_NoCardsPlayed_DisplaysHandThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[]`, and the draw pile top card is `PLACEHOLDER_CARD`.
   - **Expected output**: Displays `Sophie`'s hand, draws the `PLACEHOLDER_CARD`, adds it to `Sophie`'s hand, and advances current player to `Jordan`.
+
+- **TC3: completeTurn_SkipPlayed_DisplaysHandThenEndsWithoutDrawing** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0]`, card index `0` is `SKIP`, and the draw pile has one card.
+  - **Expected output**: Displays `Sophie`'s hand, plays and discards `SKIP`, leaves the draw pile unchanged, and advances current player to `Jordan`.

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -67,7 +67,7 @@ private Game game;
 ## Method under test: `completeTurn(List<Integer> cardIndexes)`
 | Step 1                              | Step 2     | Step 3                                  |
 |-------------------------------------|------------|-----------------------------------------|
-| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li></ul> |
+| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li></ul> |
 | Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li><li>Two cards available for See the Future</li></ul> |
 | Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li></ul> |
 
@@ -82,3 +82,7 @@ private Game game;
 - **TC4: completeTurn_SeeFuturePlayed_DisplaysFutureThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0]`, card index `0` is `SEE_THE_FUTURE`, and the draw pile has two cards.
   - **Expected output**: Displays `Sophie`'s hand, plays and discards `SEE_THE_FUTURE`, displays the top two draw pile cards, draws the top card, and advances current player to `Jordan`.
+
+- **TC5: completeTurn_TwoSeeFutureCardsPlayed_DisplaysBothThenDrawsAndAdvances** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0, 0]`, both selected cards are `SEE_THE_FUTURE`, and the draw pile has two cards.
+  - **Expected output**: Displays `Sophie`'s hand, plays and discards both `SEE_THE_FUTURE` cards, displays the top two draw pile cards after each play, draws the top card, and advances current player to `Jordan`.

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -67,9 +67,9 @@ private Game game;
 ## Method under test: `completeTurn(List<Integer> cardIndexes)`
 | Step 1                              | Step 2     | Step 3                                  |
 |-------------------------------------|------------|-----------------------------------------|
-| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li></ul> |
+| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li><li>Selected See the Future followed by selected Skip</li></ul> |
 | Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li><li>Two cards available for See the Future</li><li>Two cards available to shuffle before drawing</li></ul> |
-| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li><li>Shuffles the draw pile, then draws when Shuffle is played</li></ul> |
+| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li><li>Shuffles the draw pile, then draws when Shuffle is played</li><li>Ends turn without drawing when Skip is played after a non-ending card</li></ul> |
 
 - **TC2: completeTurn_NoCardsPlayed_DisplaysHandThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[]`, and the draw pile top card is `PLACEHOLDER_CARD`.
@@ -90,3 +90,7 @@ private Game game;
 - **TC6: completeTurn_ShufflePlayed_ShufflesThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0]`, card index `0` is `SHUFFLE`, and the draw pile has two cards with injected deterministic randomness.
   - **Expected output**: Displays `Sophie`'s hand, plays and discards `SHUFFLE`, shuffles the draw pile using the injected random source, draws the new top card, and advances current player to `Jordan`.
+
+- **TC7: completeTurn_SeeFutureThenSkipPlayed_EndsWithoutDrawing** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0, 0]`, the first selected card is `SEE_THE_FUTURE`, the second selected card is `SKIP`, and the draw pile has two cards.
+  - **Expected output**: Displays `Sophie`'s hand, plays and discards `SEE_THE_FUTURE`, displays the top two draw pile cards, plays and discards `SKIP`, leaves the draw pile unchanged, and advances current player to `Jordan`.

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -67,9 +67,9 @@ private Game game;
 ## Method under test: `completeTurn(List<Integer> cardIndexes)`
 | Step 1                              | Step 2     | Step 3                                  |
 |-------------------------------------|------------|-----------------------------------------|
-| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li><li>Selected See the Future followed by selected Skip</li><li>Selected Skip followed by another card</li><li>One selected unplayable card index</li></ul> |
+| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li><li>Selected See the Future followed by selected Skip</li><li>Selected Skip followed by another card</li><li>One selected unplayable card index</li><li>One selected index equal to hand size</li></ul> |
 | Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li><li>Two cards available for See the Future</li><li>Two cards available to shuffle before drawing</li></ul> |
-| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li><li>Shuffles the draw pile, then draws when Shuffle is played</li><li>Ends turn without drawing when Skip is played after a non-ending card</li><li>Ignores later selected cards after Skip ends the turn</li><li>Displays error for an unplayable selected card</li></ul> |
+| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li><li>Shuffles the draw pile, then draws when Shuffle is played</li><li>Ends turn without drawing when Skip is played after a non-ending card</li><li>Ignores later selected cards after Skip ends the turn</li><li>Displays error for an unplayable selected card</li><li>Displays error for an out-of-bounds selected index</li></ul> |
 
 - **TC2: completeTurn_NoCardsPlayed_DisplaysHandThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[]`, and the draw pile top card is `PLACEHOLDER_CARD`.
@@ -102,3 +102,7 @@ private Game game;
 - **TC9: completeTurn_UnplayableCard_DisplaysErrorThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0]`, card index `0` is `DEFUSE`, and the draw pile top card is `PLACEHOLDER_CARD`.
   - **Expected output**: Displays `Sophie`'s hand, displays an error because `DEFUSE` cannot be played during a normal turn, keeps `DEFUSE` in `Sophie`'s hand, draws the top card, and advances current player to `Jordan`.
+
+- **TC10: completeTurn_IndexEqualsHandSize_DisplaysErrorThenDrawsAndAdvances** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card index is equal to `Sophie`'s hand size, and the draw pile top card is `PLACEHOLDER_CARD`.
+  - **Expected output**: Displays `Sophie`'s hand, displays an out-of-bounds error, keeps the hand's existing card, draws the top card, and advances current player to `Jordan`.

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -67,9 +67,9 @@ private Game game;
 ## Method under test: `completeTurn(List<Integer> cardIndexes)`
 | Step 1                              | Step 2     | Step 3                                  |
 |-------------------------------------|------------|-----------------------------------------|
-| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li><li>Selected See the Future followed by selected Skip</li><li>Selected Skip followed by another card</li></ul> |
+| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li><li>Selected See the Future followed by selected Skip</li><li>Selected Skip followed by another card</li><li>One selected unplayable card index</li></ul> |
 | Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li><li>Two cards available for See the Future</li><li>Two cards available to shuffle before drawing</li></ul> |
-| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li><li>Shuffles the draw pile, then draws when Shuffle is played</li><li>Ends turn without drawing when Skip is played after a non-ending card</li><li>Ignores later selected cards after Skip ends the turn</li></ul> |
+| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li><li>Shuffles the draw pile, then draws when Shuffle is played</li><li>Ends turn without drawing when Skip is played after a non-ending card</li><li>Ignores later selected cards after Skip ends the turn</li><li>Displays error for an unplayable selected card</li></ul> |
 
 - **TC2: completeTurn_NoCardsPlayed_DisplaysHandThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[]`, and the draw pile top card is `PLACEHOLDER_CARD`.
@@ -98,3 +98,7 @@ private Game game;
 - **TC8: completeTurn_SkipThenSeeFuturePlayed_IgnoresCardsAfterTurnEnds** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0, 0]`, the first selected card is `SKIP`, the next selected card would be `SEE_THE_FUTURE`, and the draw pile has two cards.
   - **Expected output**: Displays `Sophie`'s hand, plays and discards `SKIP`, leaves `SEE_THE_FUTURE` in `Sophie`'s hand, does not display future cards, leaves the draw pile unchanged, and advances current player to `Jordan`.
+
+- **TC9: completeTurn_UnplayableCard_DisplaysErrorThenDrawsAndAdvances** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0]`, card index `0` is `DEFUSE`, and the draw pile top card is `PLACEHOLDER_CARD`.
+  - **Expected output**: Displays `Sophie`'s hand, displays an error because `DEFUSE` cannot be played during a normal turn, keeps `DEFUSE` in `Sophie`'s hand, draws the top card, and advances current player to `Jordan`.

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -67,9 +67,9 @@ private Game game;
 ## Method under test: `completeTurn(List<Integer> cardIndexes)`
 | Step 1                              | Step 2     | Step 3                                  |
 |-------------------------------------|------------|-----------------------------------------|
-| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li><li>Selected See the Future followed by selected Skip</li></ul> |
+| Input: selected card indexes to play | Collection | Values: <ul><li>Empty list</li><li>One selected Skip card index</li><li>One selected See the Future card index</li><li>More than one selected See the Future card index</li><li>One selected Shuffle card index</li><li>Selected See the Future followed by selected Skip</li><li>Selected Skip followed by another card</li></ul> |
 | Internal state: draw pile           | Collection | Values: <ul><li>One drawable non-Exploding-Kitten card</li><li>Two cards available for See the Future</li><li>Two cards available to shuffle before drawing</li></ul> |
-| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li><li>Shuffles the draw pile, then draws when Shuffle is played</li><li>Ends turn without drawing when Skip is played after a non-ending card</li></ul> |
+| Output                              | State / UI | Values: <ul><li>Displays hand</li><li>Draws one card</li><li>Advances to next player</li><li>Ends turn without drawing when Skip is played</li><li>Displays future cards, then draws when See the Future is played</li><li>Shuffles the draw pile, then draws when Shuffle is played</li><li>Ends turn without drawing when Skip is played after a non-ending card</li><li>Ignores later selected cards after Skip ends the turn</li></ul> |
 
 - **TC2: completeTurn_NoCardsPlayed_DisplaysHandThenDrawsAndAdvances** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[]`, and the draw pile top card is `PLACEHOLDER_CARD`.
@@ -94,3 +94,7 @@ private Game game;
 - **TC7: completeTurn_SeeFutureThenSkipPlayed_EndsWithoutDrawing** (:white_check_mark:)
   - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0, 0]`, the first selected card is `SEE_THE_FUTURE`, the second selected card is `SKIP`, and the draw pile has two cards.
   - **Expected output**: Displays `Sophie`'s hand, plays and discards `SEE_THE_FUTURE`, displays the top two draw pile cards, plays and discards `SKIP`, leaves the draw pile unchanged, and advances current player to `Jordan`.
+
+- **TC8: completeTurn_SkipThenSeeFuturePlayed_IgnoresCardsAfterTurnEnds** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, selected card indexes are `[0, 0]`, the first selected card is `SKIP`, the next selected card would be `SEE_THE_FUTURE`, and the draw pile has two cards.
+  - **Expected output**: Displays `Sophie`'s hand, plays and discards `SKIP`, leaves `SEE_THE_FUTURE` in `Sophie`'s hand, does not display future cards, leaves the draw pile unchanged, and advances current player to `Jordan`.

--- a/docs/bva/GameView.md
+++ b/docs/bva/GameView.md
@@ -59,6 +59,18 @@
         - **State of the system**: call function `displayGameReady()`
         - **Expected output**: Console shows "Game is ready! Let's begin!"
 
+### Method under test: `public void displayHand(String playerName, List<Card> cards)`
+| Step 1                 | Step 2     | Step 3                                                    |
+|------------------------|------------|-----------------------------------------------------------|
+| Input 1: player name   | String     | Values: <ul><li>Valid player name</li></ul>              |
+| Input 2: cards in hand | Collection | Values: <ul><li>More than one card</li></ul>             |
+| Output: console output | String     | Values: <ul><li>Player name and indexed card list</li></ul> |
+
+- **Step 4:**
+    - **TC10: displayHand_WithCards_ShowsPlayerNameAndIndexedCards** (:white_check_mark:)
+        - **State of the system**: call `displayHand("Sophie", [SKIP, BEARD_CAT])`
+        - **Expected output**: Console shows "Sophie, your hand:", "1. SKIP", and "2. BEARD_CAT"
+
 ### Method under test: `public void displayGameOver(String winnerName)`
 | Step 1                 | Step 2 | Step 3                                                     |
 |------------------------|--------|------------------------------------------------------------|

--- a/docs/bva/SkipCardController.md
+++ b/docs/bva/SkipCardController.md
@@ -67,6 +67,10 @@
   - **State of system**: Current player has [`DEFUSE`], `cardIndex = 0`, discard pile is empty
   - **Expected output**: Returns `false`, displays an error message, keeps `DEFUSE` in hand, and discard pile stays empty.
 
+- **TC14: playSkip_InvalidCard_DoesNotAdvanceTurn** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, current player has [`DEFUSE`], and `cardIndex = 0`
+  - **Expected output**: Returns `false`, displays an error message, keeps `DEFUSE` in hand, and keeps the current player as `Sophie`.
+
 - **TC10: controllerPlaySkip_NegativeIndex_ReturnsFalseAndDisplaysError** (:white_check_mark:)
   - **State of system**: Current player has [`SKIP`], `cardIndex = -1`, discard pile is empty
   - **Expected output**: Returns `false`, displays an error message, keeps `SKIP` in hand, and discard pile stays empty.

--- a/docs/bva/SkipCardController.md
+++ b/docs/bva/SkipCardController.md
@@ -52,12 +52,16 @@
 | Input 1: `cardIndex` | Array Index | Values: <ul><li>`-1`</li><li>`0`</li><li>`getHandSize()`</li></ul> |
 | Internal state 1: current player hand | Card Collection | Values: <ul><li>Selected card is `SKIP`</li><li>Selected card is not `SKIP`, such as `DEFUSE`</li></ul> |
 | Internal state 2: model/view/controller dependencies | Object References | Values: <ul><li>Valid `Game` model</li><li>Valid `GameView` view</li></ul> |
-| Output | Boolean / UI Message / State Change | Values: <ul><li>Returns `true` when Skip is successfully played</li><li>Displays success message</li><li>Returns `false` when selected card cannot be played</li><li>Displays error message for invalid input</li></ul> |
+| Output | Boolean / UI Message / State Change | Values: <ul><li>Returns `true` when Skip is successfully played</li><li>Displays success message</li><li>Ends the turn without drawing</li><li>Advances to the next player</li><li>Returns `false` when selected card cannot be played</li><li>Displays error message for invalid input</li></ul> |
 
 ### Test Cases 
 - **TC8: controllerPlaySkip_ValidSkip_ReturnsTrueAndDisplaysMessage** (:white_check_mark:)
   - **State of system**: Current player has [`SKIP`], `cardIndex = 0`, discard pile is empty
   - **Expected output**: Returns `true`, displays `"Skip played. Your turn ends without drawing a card."`, removes `SKIP` from hand, and adds it to discard pile.
+
+- **TC13: playSkip_ValidSkip_AdvancesToNextPlayerWithoutDrawing** (:white_check_mark:)
+  - **State of system**: Current player is `Sophie`, next player is `Jordan`, current player has [`SKIP`], and the draw pile has at least one card
+  - **Expected output**: Returns `true`, removes and discards `SKIP`, leaves the draw pile unchanged, and advances the current player to `Jordan`.
 
 - **TC9: playSkip_SelectedCardIsDefuse_ReturnsFalseAndDisplaysError** (:white_check_mark:)
   - **State of system**: Current player has [`DEFUSE`], `cardIndex = 0`, discard pile is empty

--- a/docs/bva/TakeCard.md
+++ b/docs/bva/TakeCard.md
@@ -26,6 +26,10 @@
         - **State of system**: Current player hand = [], draw pile top card = `EXPLODING_KITTEN`, 3 active players
         - **Expected output**: Returns `EXPLODING_KITTEN`, does not add it to the player's hand, removes the player from the game, leaves 2 active players, and does not display game over
 
+    - **TC11: takeCard_ExplodingKittenWithoutDefuse_CurrentPlayerIsNextRemainingPlayer** (:white_check_mark:)
+        - **State of system**: Current player is `Avery`, next player is `Jordan`, current player hand = [], draw pile top card = `EXPLODING_KITTEN`, 3 active players
+        - **Expected output**: Returns `EXPLODING_KITTEN`, removes `Avery` from the game, and leaves `Jordan` as the current player without advancing past them
+
     - **TC7: takeCard_ExplodingKittenWithoutDefuse_EliminatesPlayerAndDisplaysWinner** (:white_check_mark:)
         - **State of system**: Current player hand = [], draw pile top card = `EXPLODING_KITTEN`, 2 active players
         - **Expected output**: Returns `EXPLODING_KITTEN`, does not add it to the player's hand, removes the player from the game, leaves 1 active player, and displays game over with the remaining player's name

--- a/docs/bva/TakeCard.md
+++ b/docs/bva/TakeCard.md
@@ -18,6 +18,10 @@
         - **State of system**: Deck size = 3, Deck = [Card_A, Card_B, Card_C], Player hand = []
         - **Expected output**: Returns Card_C, Deck becomes [Card_A, Card_B] (size = 2), Player hand = [Card_C] (size = 1)
 
+    - **TC9: takeCard_NonExplodingCard_AdvancesToNextPlayer** (:white_check_mark:)
+        - **State of system**: Current player is `player1`, next player is `player2`, draw pile top card is a non-Exploding Kitten
+        - **Expected output**: Returns the drawn card, adds it to `player1`'s hand, and advances the current player to `player2`
+
     - **TC6: takeCard_ExplodingKittenWithoutDefuse_EliminatesPlayerAndGameContinues** (:white_check_mark:)
         - **State of system**: Current player hand = [], draw pile top card = `EXPLODING_KITTEN`, 3 active players
         - **Expected output**: Returns `EXPLODING_KITTEN`, does not add it to the player's hand, removes the player from the game, leaves 2 active players, and does not display game over

--- a/docs/bva/TakeCard.md
+++ b/docs/bva/TakeCard.md
@@ -32,7 +32,11 @@
 
     - **TC8: takeCard_ExplodingKittenWithDefuse_DefusesAndReinsertsKitten** (:white_check_mark:)
         - **State of system**: Current player hand = [`DEFUSE`], draw pile top card = `EXPLODING_KITTEN`
-        - **Expected output**: Returns `EXPLODING_KITTEN`, removes one `DEFUSE` from the hand, adds it to the discard pile, returns the kitten to the draw pile, and keeps the player active
+        - **Expected output**: Returns `EXPLODING_KITTEN`, removes one `DEFUSE` from the hand, adds it to the discard pile, returns the kitten to the draw pile, keeps the player active, and advances to the next player because the turn is over after playing Defuse
+
+    - **TC10: takeCard_ExplodingKittenWithDefuse_AdvancesToNextPlayer** (:white_check_mark:)
+        - **State of system**: Current player is `Avery`, next player is `Jordan`, current player hand = [`DEFUSE`], draw pile top card = `EXPLODING_KITTEN`
+        - **Expected output**: Returns `EXPLODING_KITTEN`, defuses the kitten, and advances the current player to `Jordan`
 
 
 ### Method under test: `public void displayCardDrawn(Card card)` view method

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -48,6 +48,7 @@ public class GameController {
         }
         currentPlayer.addCard(drawnCard);
         view.displayCardDrawn(drawnCard);
+        model.advanceTurn();
         return drawnCard;
     }
 

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -43,6 +43,11 @@ public class GameController {
             if (selectedCard.getType() == CardType.SKIP && playSkip(cardIndex)) {
                 return;
             }
+            if (selectedCard.getType() == CardType.SEE_THE_FUTURE) {
+                SeeFutureCardController seeFutureController =
+                        new SeeFutureCardController(model.getDrawPile(), model.getDiscardPile());
+                view.displaySeeTheFutureCards(seeFutureController.play(currentPlayer, cardIndex));
+            }
         }
         takeCard();
     }

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -48,6 +48,10 @@ public class GameController {
                         new SeeFutureCardController(model.getDrawPile(), model.getDiscardPile());
                 view.displaySeeTheFutureCards(seeFutureController.play(currentPlayer, cardIndex));
             }
+            if (selectedCard.getType() == CardType.SHUFFLE) {
+                ShuffleCardController shuffleCardController = new ShuffleCardController();
+                shuffleCardController.play(model, cardIndex);
+            }
         }
         takeCard();
     }

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -37,6 +37,13 @@ public class GameController {
 
     public void completeTurn(List<Integer> cardIndexes) {
         startTurn();
+        for (int cardIndex : cardIndexes) {
+            Player currentPlayer = model.getCurrentPlayer();
+            Card selectedCard = currentPlayer.getHandSnapshot().get(cardIndex);
+            if (selectedCard.getType() == CardType.SKIP && playSkip(cardIndex)) {
+                return;
+            }
+        }
         takeCard();
     }
 

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -35,6 +35,11 @@ public class GameController {
         view.displayHand(currentPlayer.getName(), currentPlayer.getHandSnapshot());
     }
 
+    public void completeTurn(List<Integer> cardIndexes) {
+        startTurn();
+        takeCard();
+    }
+
     public Card takeCard() {
         Player currentPlayer = model.getCurrentPlayer();
         Card drawnCard = model.getDrawPile().draw();

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -62,6 +62,7 @@ public class GameController {
 
             skipCardController.play(currentPlayer, cardIndex);
             view.displayMessage(SKIP_PLAYED);
+            model.advanceTurn();
             return true;
         } catch (IllegalArgumentException | IndexOutOfBoundsException e) {
             view.displayError(e.getMessage());

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 public class GameController {
     private static final String SKIP_PLAYED = "Skip played. Your turn ends without drawing a card.";
+    private static final String UNPLAYABLE_CARD =
+            "Card cannot be played during a normal turn.";
 
     // Open to discussion here  
     @SuppressFBWarnings(
@@ -47,11 +49,14 @@ public class GameController {
                 SeeFutureCardController seeFutureController =
                         new SeeFutureCardController(model.getDrawPile(), model.getDiscardPile());
                 view.displaySeeTheFutureCards(seeFutureController.play(currentPlayer, cardIndex));
+                continue;
             }
             if (selectedCard.getType() == CardType.SHUFFLE) {
                 ShuffleCardController shuffleCardController = new ShuffleCardController();
                 shuffleCardController.play(model, cardIndex);
+                continue;
             }
+            view.displayError(UNPLAYABLE_CARD);
         }
         takeCard();
     }

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -30,6 +30,11 @@ public class GameController {
         }
     }
 
+    public void startTurn() {
+        Player currentPlayer = model.getCurrentPlayer();
+        view.displayHand(currentPlayer.getName(), currentPlayer.getHandSnapshot());
+    }
+
     public Card takeCard() {
         Player currentPlayer = model.getCurrentPlayer();
         Card drawnCard = model.getDrawPile().draw();

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -38,7 +38,9 @@ public class GameController {
             ExplodingKittenCardController explodingKittenController =
                     new ExplodingKittenCardController(model.getDrawPile(), model.getDiscardPile());
             boolean defused = explodingKittenController.play(currentPlayer, drawnCard);
-            if (!defused) {
+            if (defused) {
+                model.advanceTurn();
+            } else {
                 model.eliminatePlayer(currentPlayer);
                 if (model.isWon()) {
                     view.displayGameOver(model.getPlayers().get(0).getName());

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -9,6 +9,7 @@ public class GameController {
     private static final String SKIP_PLAYED = "Skip played. Your turn ends without drawing a card.";
     private static final String UNPLAYABLE_CARD =
             "Card cannot be played during a normal turn.";
+    private static final String INVALID_CARD_INDEX = "cardIndex is out of bounds";
 
     // Open to discussion here  
     @SuppressFBWarnings(
@@ -41,6 +42,10 @@ public class GameController {
         startTurn();
         for (int cardIndex : cardIndexes) {
             Player currentPlayer = model.getCurrentPlayer();
+            if (cardIndex < 0 || cardIndex >= currentPlayer.getHandSize()) {
+                view.displayError(INVALID_CARD_INDEX);
+                continue;
+            }
             Card selectedCard = currentPlayer.getHandSnapshot().get(cardIndex);
             if (selectedCard.getType() == CardType.SKIP && playSkip(cardIndex)) {
                 return;

--- a/src/main/java/ui/GameView.java
+++ b/src/main/java/ui/GameView.java
@@ -56,6 +56,17 @@ public class GameView {
         System.out.println(message);
 
     }
+
+    public void displayHand(String playerName, List<Card> cards) {
+        String title = MessageFormat.format(messages.getString("hand.title"), playerName);
+        System.out.println(title);
+
+        for (int i = 0; i < cards.size(); i++) {
+            String cardLine = MessageFormat.format(messages.getString("hand.card.format"),
+                    i + 1, cards.get(i).getType());
+            System.out.println(cardLine);
+        }
+    }
       
     public void displaySeeTheFutureCards(List<Card> cards) {
 

--- a/src/main/resources/message_de.properties
+++ b/src/main/resources/message_de.properties
@@ -12,6 +12,9 @@ error.prefix=Fehler:
 card.drawn.message=Du hast gezogen: {0}
 error.cards.not.null=Die Kartenliste darf nicht null sein
 
+hand.title={0}, deine Hand:
+hand.card.format={0}. {1}
+
 see.future.title=In die Zukunft blicken: Die obersten Karten im Stapel:
 see.future.no.cards=Keine Karten zum Anzeigen.
 see.future.card.format={0}. {1}

--- a/src/main/resources/message_en.properties
+++ b/src/main/resources/message_en.properties
@@ -12,6 +12,9 @@ error.prefix=Error:
 card.drawn.message=You drew: {0}
 error.cards.not.null=Cards list must not be null
 
+hand.title={0}, your hand:
+hand.card.format={0}. {1}
+
 see.future.title=See the Future: Top cards in the draw pile:
 see.future.no.cards=No cards to view.
 see.future.card.format={0}. {1}

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -178,6 +178,29 @@ public class GameControllerTest {
     }
 
     @Test
+    void startTurn_DisplaysCurrentPlayerHand() {
+        Game mockModel = EasyMock.createMock(Game.class);
+        GameView mockView = EasyMock.createMock(GameView.class);
+        Player player = new Player("Sophie");
+        Card skip = new Card(CardType.SKIP);
+        Card beardCat = new Card(CardType.BEARD_CAT);
+        player.addCard(skip);
+        player.addCard(beardCat);
+
+        expect(mockModel.getCurrentPlayer()).andReturn(player).once();
+        replay(mockModel);
+        mockView.displayHand("Sophie", List.of(skip, beardCat));
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(mockModel, mockView);
+
+        controller.startTurn();
+
+        verify(mockModel);
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_DeckSizeZero_ThrowsException() {
         List<Card> cards = new ArrayList<>();
         cards.add(new Card(CardType.DEFUSE));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -347,6 +347,29 @@ public class GameControllerTest {
     }
 
     @Test
+    void takeCard_ExplodingKittenWithoutDefuse_CurrentPlayerIsNextRemainingPlayer() {
+        Game game = new Game(createDeckForPlayers(3));
+        game.setupGame(List.of("Avery", "Jordan", "Casey"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        clearDrawPile(game.getDrawPile());
+        Card explodingKitten = new Card(CardType.EXPLODING_KITTEN);
+        game.getDrawPile().addCard(explodingKitten);
+        GameView mockView = EasyMock.createMock(GameView.class);
+        mockView.displayCardDrawn(explodingKitten);
+        expectLastCall().once();
+        EasyMock.replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        Card drawnCard = controller.takeCard();
+
+        assertEquals(explodingKitten, drawnCard);
+        assertFalse(game.getPlayers().contains(currentPlayer));
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_ExplodingKittenWithoutDefuse_EliminatesPlayerAndDisplaysWinner() {
         Game game = new Game(createDeckForPlayers(2));
         game.setupGame(List.of("Avery", "Jordan"));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -288,6 +288,43 @@ public class GameControllerTest {
     }
 
     @Test
+    void completeTurn_TwoSeeFutureCardsPlayed_DisplaysBothThenDrawsAndAdvances() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        Card firstSeeFuture = new Card(CardType.SEE_THE_FUTURE);
+        Card secondSeeFuture = new Card(CardType.SEE_THE_FUTURE);
+        currentPlayer.addCard(firstSeeFuture);
+        currentPlayer.addCard(secondSeeFuture);
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        Card secondFutureCard = new Card(CardType.BEARD_CAT);
+        Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
+        game.getDrawPile().addCard(secondFutureCard);
+        game.getDrawPile().addCard(drawnCard);
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displaySeeTheFutureCards(List.of(drawnCard, secondFutureCard));
+        expectLastCall().once();
+        mockView.displaySeeTheFutureCards(List.of(drawnCard, secondFutureCard));
+        expectLastCall().once();
+        mockView.displayCardDrawn(drawnCard);
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of(0, 0));
+
+        assertEquals(1, currentPlayer.getHandSize());
+        assertEquals(List.of(firstSeeFuture, secondSeeFuture), game.getDiscardPile().snapshot());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_DeckSizeZero_ThrowsException() {
         List<Card> cards = new ArrayList<>();
         cards.add(new Card(CardType.DEFUSE));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -398,6 +398,39 @@ public class GameControllerTest {
     }
 
     @Test
+    void completeTurn_SkipThenSeeFuturePlayed_IgnoresCardsAfterTurnEnds() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        Card skip = new Card(CardType.SKIP);
+        Card seeFuture = new Card(CardType.SEE_THE_FUTURE);
+        currentPlayer.addCard(skip);
+        currentPlayer.addCard(seeFuture);
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        game.getDrawPile().addCard(new Card(CardType.BEARD_CAT));
+        game.getDrawPile().addCard(new Card(CardType.PLACEHOLDER_CARD));
+        int drawPileSize = game.getDrawPile().size();
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displayMessage("Skip played. Your turn ends without drawing a card.");
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of(0, 0));
+
+        assertEquals(List.of(seeFuture), currentPlayer.getHandSnapshot());
+        assertEquals(List.of(skip), game.getDiscardPile().snapshot());
+        assertEquals(drawPileSize, game.getDrawPile().size());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_DeckSizeZero_ThrowsException() {
         List<Card> cards = new ArrayList<>();
         cards.add(new Card(CardType.DEFUSE));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -226,6 +226,35 @@ public class GameControllerTest {
     }
 
     @Test
+    void completeTurn_SkipPlayed_DisplaysHandThenEndsWithoutDrawing() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        Card skip = new Card(CardType.SKIP);
+        currentPlayer.addCard(skip);
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        game.getDrawPile().addCard(new Card(CardType.PLACEHOLDER_CARD));
+        int drawPileSize = game.getDrawPile().size();
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displayMessage("Skip played. Your turn ends without drawing a card.");
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of(0));
+
+        assertEquals(0, currentPlayer.getHandSize());
+        assertEquals(drawPileSize, game.getDrawPile().size());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_DeckSizeZero_ThrowsException() {
         List<Card> cards = new ArrayList<>();
         cards.add(new Card(CardType.DEFUSE));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 import ui.GameView;
@@ -320,6 +321,41 @@ public class GameControllerTest {
 
         assertEquals(1, currentPlayer.getHandSize());
         assertEquals(List.of(firstSeeFuture, secondSeeFuture), game.getDiscardPile().snapshot());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
+    void completeTurn_ShufflePlayed_ShufflesThenDrawsAndAdvances() {
+        CountingZeroRandom random = new CountingZeroRandom();
+        Game game = new Game(createDeckForPlayers(2, random));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        random.resetCalls();
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        Card shuffle = new Card(CardType.SHUFFLE);
+        currentPlayer.addCard(shuffle);
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        Card drawnCardAfterShuffle = new Card(CardType.PLACEHOLDER_CARD);
+        Card remainingCardAfterDraw = new Card(CardType.BEARD_CAT);
+        game.getDrawPile().addCard(drawnCardAfterShuffle);
+        game.getDrawPile().addCard(remainingCardAfterDraw);
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displayCardDrawn(drawnCardAfterShuffle);
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of(0));
+
+        assertEquals(1, currentPlayer.getHandSize());
+        assertEquals(List.of(shuffle), game.getDiscardPile().snapshot());
+        assertEquals(List.of(remainingCardAfterDraw), game.getDrawPile().snapshot());
+        assertEquals(List.of(2), random.getBoundsSinceReset());
         assertEquals("Jordan", game.getCurrentPlayer().getName());
         verify(mockView);
     }
@@ -787,6 +823,10 @@ public class GameControllerTest {
     }
 
     private Deck createDeckForPlayers(int playerCount) {
+        return createDeckForPlayers(playerCount, new Random());
+    }
+
+    private Deck createDeckForPlayers(int playerCount, Random random) {
         List<Card> cards = new ArrayList<>();
         for (int count = 0; count < playerCount - 1; count++) {
             cards.add(new Card(CardType.EXPLODING_KITTEN));
@@ -797,7 +837,7 @@ public class GameControllerTest {
         for (int count = 0; count < playerCount * 5; count++) {
             cards.add(new Card(CardType.PLACEHOLDER_CARD));
         }
-        return new Deck(cards);
+        return new Deck(cards, random);
     }
 
     private void clearHand(Player player) {
@@ -809,6 +849,24 @@ public class GameControllerTest {
     private void clearDrawPile(Deck drawPile) {
         while (drawPile.size() > 0) {
             drawPile.draw();
+        }
+    }
+
+    private static final class CountingZeroRandom extends Random {
+        private final List<Integer> boundsSinceReset = new ArrayList<>();
+
+        @Override
+        public int nextInt(int bound) {
+            boundsSinceReset.add(bound);
+            return 0;
+        }
+
+        void resetCalls() {
+            boundsSinceReset.clear();
+        }
+
+        List<Integer> getBoundsSinceReset() {
+            return List.copyOf(boundsSinceReset);
         }
     }
 

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -201,6 +201,31 @@ public class GameControllerTest {
     }
 
     @Test
+    void completeTurn_NoCardsPlayed_DisplaysHandThenDrawsAndAdvances() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
+        game.getDrawPile().addCard(drawnCard);
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displayCardDrawn(drawnCard);
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of());
+
+        assertEquals(7, currentPlayer.getHandSize());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_DeckSizeZero_ThrowsException() {
         List<Card> cards = new ArrayList<>();
         cards.add(new Card(CardType.DEFUSE));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -431,6 +431,37 @@ public class GameControllerTest {
     }
 
     @Test
+    void completeTurn_UnplayableCard_DisplaysErrorThenDrawsAndAdvances() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        Card defuse = new Card(CardType.DEFUSE);
+        currentPlayer.addCard(defuse);
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
+        game.getDrawPile().addCard(drawnCard);
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displayError("Card cannot be played during a normal turn.");
+        expectLastCall().once();
+        mockView.displayCardDrawn(drawnCard);
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of(0));
+
+        assertEquals(List.of(defuse, drawnCard), currentPlayer.getHandSnapshot());
+        assertEquals(List.of(), game.getDiscardPile().snapshot());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_DeckSizeZero_ThrowsException() {
         List<Card> cards = new ArrayList<>();
         cards.add(new Card(CardType.DEFUSE));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -224,6 +224,7 @@ public class GameControllerTest {
         GameView mockView = EasyMock.createMock(GameView.class);
         List<String> players = List.of("player1", "player2");
         game.setupGame(players);
+        Player drawingPlayer = game.getCurrentPlayer();
 
         clearDrawPile(game.getDrawPile());
         Card expectedCard = new Card(CardType.PLACEHOLDER_CARD);
@@ -242,7 +243,7 @@ public class GameControllerTest {
 
         assertEquals(expectedCard, result);
         assertEquals(0, game.getDrawPile().size());
-        assertEquals(7, game.getCurrentPlayer().getHandSize());
+        assertEquals(7, drawingPlayer.getHandSize());
 
         verify(mockView);
     }
@@ -284,6 +285,39 @@ public class GameControllerTest {
         assertEquals(expectedCard, result);
         assertEquals(beforeSize - 1, game.getDrawPile().size());
 
+        verify(mockView);
+    }
+
+    @Test
+    void takeCard_NonExplodingCard_AdvancesToNextPlayer() {
+        List<Card> cards = new ArrayList<>();
+        cards.add(new Card(CardType.DEFUSE));
+        cards.add(new Card(CardType.DEFUSE));
+
+        for (int i = 0; i < 10; i++) {
+            cards.add(new Card(CardType.PLACEHOLDER_CARD));
+        }
+        cards.add(new Card(CardType.EXPLODING_KITTEN));
+
+        Deck deck = new Deck(cards);
+        Game game = new Game(deck);
+        GameView mockView = EasyMock.createMock(GameView.class);
+        game.setupGame(List.of("player1", "player2"));
+        Player drawingPlayer = game.getCurrentPlayer();
+        clearDrawPile(game.getDrawPile());
+        Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
+        game.getDrawPile().addCard(drawnCard);
+
+        mockView.displayCardDrawn(drawnCard);
+        expectLastCall().once();
+        EasyMock.replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        Card result = controller.takeCard();
+
+        assertEquals(drawnCard, result);
+        assertEquals(7, drawingPlayer.getHandSize());
+        assertEquals("player2", game.getCurrentPlayer().getName());
         verify(mockView);
     }
 

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -532,6 +532,28 @@ public class GameControllerTest {
     }
 
     @Test
+    void playSkip_InvalidCard_DoesNotAdvanceTurn() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        currentPlayer.addCard(new Card(CardType.DEFUSE));
+
+        mockView.displayError(anyString());
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        boolean result = controller.playSkip(0);
+
+        assertFalse(result);
+        assertEquals("Sophie", game.getCurrentPlayer().getName());
+        assertEquals(1, currentPlayer.getHandSize());
+        verify(mockView);
+    }
+
+    @Test
     void playSkip_NegativeIndex_ReturnsFalseAndDisplaysError() {
         Game mockModel = EasyMock.createMock(Game.class);
         GameView mockView = EasyMock.createMock(GameView.class);

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -402,6 +402,29 @@ public class GameControllerTest {
     }
 
     @Test
+    void takeCard_ExplodingKittenWithDefuse_AdvancesToNextPlayer() {
+        Game game = new Game(createDeckForPlayers(2));
+        game.setupGame(List.of("Avery", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        currentPlayer.addCard(new Card(CardType.DEFUSE));
+        clearDrawPile(game.getDrawPile());
+        Card explodingKitten = new Card(CardType.EXPLODING_KITTEN);
+        game.getDrawPile().addCard(explodingKitten);
+        GameView mockView = EasyMock.createMock(GameView.class);
+        mockView.displayCardDrawn(explodingKitten);
+        expectLastCall().once();
+        EasyMock.replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        Card drawnCard = controller.takeCard();
+
+        assertEquals(explodingKitten, drawnCard);
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void playSkip_ValidSkip_ReturnsTrueAndDisplaysMessage() {
         Game mockModel = EasyMock.createMock(Game.class);
         GameView mockView = EasyMock.createMock(GameView.class);

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -462,6 +462,37 @@ public class GameControllerTest {
     }
 
     @Test
+    void completeTurn_IndexEqualsHandSize_DisplaysErrorThenDrawsAndAdvances() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        Card seeFuture = new Card(CardType.SEE_THE_FUTURE);
+        currentPlayer.addCard(seeFuture);
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
+        game.getDrawPile().addCard(drawnCard);
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displayError("cardIndex is out of bounds");
+        expectLastCall().once();
+        mockView.displayCardDrawn(drawnCard);
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of(currentPlayer.getHandSize()));
+
+        assertEquals(List.of(seeFuture, drawnCard), currentPlayer.getHandSnapshot());
+        assertEquals(List.of(), game.getDiscardPile().snapshot());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_DeckSizeZero_ThrowsException() {
         List<Card> cards = new ArrayList<>();
         cards.add(new Card(CardType.DEFUSE));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -255,6 +255,39 @@ public class GameControllerTest {
     }
 
     @Test
+    void completeTurn_SeeFuturePlayed_DisplaysFutureThenDrawsAndAdvances() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        Card seeFuture = new Card(CardType.SEE_THE_FUTURE);
+        currentPlayer.addCard(seeFuture);
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        Card secondFutureCard = new Card(CardType.BEARD_CAT);
+        Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
+        game.getDrawPile().addCard(secondFutureCard);
+        game.getDrawPile().addCard(drawnCard);
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displaySeeTheFutureCards(List.of(drawnCard, secondFutureCard));
+        expectLastCall().once();
+        mockView.displayCardDrawn(drawnCard);
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of(0));
+
+        assertEquals(1, currentPlayer.getHandSize());
+        assertEquals(List.of(seeFuture), game.getDiscardPile().snapshot());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_DeckSizeZero_ThrowsException() {
         List<Card> cards = new ArrayList<>();
         cards.add(new Card(CardType.DEFUSE));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -458,6 +458,8 @@ public class GameControllerTest {
 
         expect(mockModel.getCurrentPlayer()).andReturn(player).once();
         expect(mockModel.getDiscardPile()).andReturn(discardPile).once();
+        mockModel.advanceTurn();
+        expectLastCall().once();
         replay(mockModel);
 
         mockView.displayMessage("Skip played. Your turn ends without drawing a card.");
@@ -475,6 +477,31 @@ public class GameControllerTest {
         verify(mockModel);
         verify(mockView);
     }
+
+    @Test
+    void playSkip_ValidSkip_AdvancesToNextPlayerWithoutDrawing() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        currentPlayer.addCard(new Card(CardType.SKIP));
+        int drawPileSize = game.getDrawPile().size();
+
+        mockView.displayMessage("Skip played. Your turn ends without drawing a card.");
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        boolean result = controller.playSkip(0);
+
+        assertTrue(result);
+        assertEquals(0, currentPlayer.getHandSize());
+        assertEquals(drawPileSize, game.getDrawPile().size());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
     @Test
     void playSkip_SelectedCardIsDefuse_ReturnsFalseAndDisplaysError() {
         Game mockModel = EasyMock.createMock(Game.class);

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -493,6 +493,37 @@ public class GameControllerTest {
     }
 
     @Test
+    void completeTurn_NegativeIndex_DisplaysErrorThenDrawsAndAdvances() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        Card seeFuture = new Card(CardType.SEE_THE_FUTURE);
+        currentPlayer.addCard(seeFuture);
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
+        game.getDrawPile().addCard(drawnCard);
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displayError("cardIndex is out of bounds");
+        expectLastCall().once();
+        mockView.displayCardDrawn(drawnCard);
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of(-1));
+
+        assertEquals(List.of(seeFuture, drawnCard), currentPlayer.getHandSnapshot());
+        assertEquals(List.of(), game.getDiscardPile().snapshot());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_DeckSizeZero_ThrowsException() {
         List<Card> cards = new ArrayList<>();
         cards.add(new Card(CardType.DEFUSE));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -361,6 +361,43 @@ public class GameControllerTest {
     }
 
     @Test
+    void completeTurn_SeeFutureThenSkipPlayed_EndsWithoutDrawing() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        Card seeFuture = new Card(CardType.SEE_THE_FUTURE);
+        Card skip = new Card(CardType.SKIP);
+        currentPlayer.addCard(seeFuture);
+        currentPlayer.addCard(skip);
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        Card secondFutureCard = new Card(CardType.BEARD_CAT);
+        Card topCard = new Card(CardType.PLACEHOLDER_CARD);
+        game.getDrawPile().addCard(secondFutureCard);
+        game.getDrawPile().addCard(topCard);
+        int drawPileSize = game.getDrawPile().size();
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displaySeeTheFutureCards(List.of(topCard, secondFutureCard));
+        expectLastCall().once();
+        mockView.displayMessage("Skip played. Your turn ends without drawing a card.");
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of(0, 0));
+
+        assertEquals(0, currentPlayer.getHandSize());
+        assertEquals(List.of(seeFuture, skip), game.getDiscardPile().snapshot());
+        assertEquals(drawPileSize, game.getDrawPile().size());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
+    @Test
     void takeCard_DeckSizeZero_ThrowsException() {
         List<Card> cards = new ArrayList<>();
         cards.add(new Card(CardType.DEFUSE));

--- a/src/test/java/ui/GameViewTest.java
+++ b/src/test/java/ui/GameViewTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
+import domain.game.Card;
+import domain.game.CardType;
 import org.junit.jupiter.api.Test;
 
 public class GameViewTest {
@@ -24,5 +27,26 @@ public class GameViewTest {
         }
 
         assertTrue(output.toString(StandardCharsets.UTF_8).contains("Game over! Jordan wins!"));
+    }
+
+    @Test
+    void displayHand_WithCards_ShowsPlayerNameAndIndexedCards() {
+        GameView view = new GameView();
+        List<Card> cards = List.of(new Card(CardType.SKIP), new Card(CardType.BEARD_CAT));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+
+        try {
+            System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
+
+            view.displayHand("Sophie", cards);
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        String text = output.toString(StandardCharsets.UTF_8);
+        assertTrue(text.contains("Sophie, your hand:"));
+        assertTrue(text.contains("1. SKIP"));
+        assertTrue(text.contains("2. BEARD_CAT"));
     }
 }


### PR DESCRIPTION
this PR implements the core turn-flow behavior

A turn now follows the ruleset flow: the current player sees their hand, may play zero or more supported cards, and then draws to end the turn unless a played card ends the turn first.

## What This PR Implements

- Finishes basic turn advancement across active players.
- Advances the turn after a normal non-Exploding Kitten draw.
- Advances the turn after a player defuses an Exploding Kitten.
- Keeps the next remaining active player current after an undefused explosion.
- Shows the current player’s hand at the start of a turn.
- Adds `completeTurn(...)` flow for terminal turn execution.
- Supports passing/playing zero cards, then drawing to end the turn.
- Supports playing multiple non-turn-ending cards before drawing.
- Supports `SEE_THE_FUTURE` during a complete turn.
- Supports `SHUFFLE` during a complete turn.
- Supports `SKIP` as a turn-ending card that advances without drawing.
- Stops processing later selected cards after `SKIP` ends the turn.
- Handles invalid selected card indexes without crashing.
- Handles unplayable cards, like `DEFUSE` during a normal turn, by showing an error and continuing to the draw step.
- Updates `GameView` so the terminal can display the current player’s hand with indexed cards.
- Updates BVA docs for the new controller/view behavior.

## Rules
- A turn is: play/pass, then draw to end the turn.
- A player may play as many cards as they want before drawing.
- `SKIP` ends the turn without drawing.
- `DEFUSE` ends the turn after the Exploding Kitten is returned.
- Play continues around active players.
- Eliminated players are removed from active play, and the next remaining player becomes current.
- The game continues until one winner remains.

## Out of Scope

`ATTACK` also ends the turn without drawing, but full Attack behavior needs forced turns, stacking, and Skip interaction. That is intentionally left as a separate larger rules task rather than partially implemented here.