### PR TITLE
updated bva with eliminated player tracking test cases

### DIFF
--- a/docs/bva/EliminatedPlayers.md
+++ b/docs/bva/EliminatedPlayers.md
@@ -43,7 +43,7 @@ The terminal should print public player state every turn:
 - **TC2: takeCard_ExplodingKittenWithoutDefuse_TracksEliminatedPlayer**
     - **State of system**: Current player draws an Exploding Kitten without a Defuse and has remaining cards.
     - **Expected output**: GameController records the eliminated player with the drawn Exploding Kitten face up and the remaining hand cards face up by type.
-    - **Implemented?** :x:
+    - **Implemented?** :white_check_mark:
 
 ---
 

--- a/docs/bva/EliminatedPlayers.md
+++ b/docs/bva/EliminatedPlayers.md
@@ -26,7 +26,7 @@ The terminal should print public player state every turn:
 - **TC1: eliminatePlayer_WithExplodingKitten_TracksFaceUpKittenAndRemainingCards**
     - **State of system**: Current player has remaining cards and is eliminated by an Exploding Kitten.
     - **Expected output**: Player is removed from active players. Eliminated player record stores the killing kitten and the remaining card types.
-    - **Implemented?** :x:
+    - **Implemented?** :white_check_mark:
 
 ---
 

--- a/docs/bva/EliminatedPlayers.md
+++ b/docs/bva/EliminatedPlayers.md
@@ -1,0 +1,81 @@
+# BVA Analysis for Tracking Eliminated Players
+
+## Feature under test: Eliminated player tracking
+
+## Rule
+
+When a player draws an Exploding Kitten and cannot Defuse it, that player is eliminated from the active player list. The killing Exploding Kitten should be shown face up in front of the eliminated player. The eliminated player's remaining hand cards should also be visible by card type.
+
+The terminal should print public player state every turn:
+- Active players are shown with face-down card counts.
+- Eliminated players are shown with the face-up killing Exploding Kitten and their remaining face-up card types.
+
+---
+
+## Method under test 1: `Game.eliminatePlayer(Player player, Card killingKitten)`
+
+| Step | Input / State | Category | Boundary values / cases |
+|---|---|---|---|
+| Step 1 | active player count | Collection size | 2 players; more than 2 players |
+| Step 2 | eliminated player hand | Collection size | empty hand; one card; more than one card |
+| Step 3 | killing card | Card type | `EXPLODING_KITTEN` |
+| Step 4 | output/state change | Collection state | player removed from active players; eliminated player record added; killing kitten stored face up; remaining hand cards stored face up by type |
+
+### Test Cases
+
+- **TC1: eliminatePlayer_WithExplodingKitten_TracksFaceUpKittenAndRemainingCards**
+    - **State of system**: Current player has remaining cards and is eliminated by an Exploding Kitten.
+    - **Expected output**: Player is removed from active players. Eliminated player record stores the killing kitten and the remaining card types.
+    - **Implemented?** :x:
+
+---
+
+## Method under test 2: `GameController.takeCard()`
+
+| Step | Input / State | Category | Boundary values / cases |
+|---|---|---|---|
+| Step 1 | drawn card | Card type | `EXPLODING_KITTEN` |
+| Step 2 | current player hand | Collection state | no Defuse; has remaining non-Defuse cards |
+| Step 3 | output/state change | Controller/model integration | current player is eliminated; killing kitten and remaining cards are recorded |
+
+### Test Cases
+
+- **TC2: takeCard_ExplodingKittenWithoutDefuse_TracksEliminatedPlayer**
+    - **State of system**: Current player draws an Exploding Kitten without a Defuse and has remaining cards.
+    - **Expected output**: GameController records the eliminated player with the drawn Exploding Kitten face up and the remaining hand cards face up by type.
+    - **Implemented?** :x:
+
+---
+
+## Method under test 3: `GameView.displayPublicPlayerState(...)`
+
+| Step | Input / State | Category | Boundary values / cases |
+|---|---|---|---|
+| Step 1 | active players | Collection size | one or more active players |
+| Step 2 | eliminated players | Collection size | no eliminated players; one eliminated player; multiple eliminated players |
+| Step 3 | eliminated player visible cards | Collection size | empty visible hand; one visible card; multiple visible cards |
+| Step 4 | output | Terminal display | active players shown with face-down card counts; eliminated players shown with face-up killing kitten and face-up remaining card types |
+
+### Test Cases
+
+- **TC3: displayPublicPlayerState_WithActiveAndEliminatedPlayers_PrintsFaceDownAndFaceUpState**
+    - **State of system**: One active player and one eliminated player with a killing kitten and remaining cards.
+    - **Expected output**: Terminal prints active player's face-down card count and eliminated player's face-up killing kitten plus remaining face-up card types.
+    - **Implemented?** :x:
+
+---
+
+## Method under test 4: `GameController.startTurn()`
+
+| Step | Input / State | Category | Boundary values / cases |
+|---|---|---|---|
+| Step 1 | start of turn | Controller flow | public state should be displayed before current player's private hand |
+| Step 2 | active and eliminated players | Model state | active players only; active plus eliminated players |
+| Step 3 | output | View interaction | view displays public state every turn |
+
+### Test Cases
+
+- **TC4: startTurn_DisplaysPublicPlayerStateThenCurrentPlayerHand**
+    - **State of system**: Game has active players and may have eliminated player records.
+    - **Expected output**: View displays public player state, then displays the current player's hand.
+    - **Implemented?** :x:

--- a/docs/bva/EliminatedPlayers.md
+++ b/docs/bva/EliminatedPlayers.md
@@ -61,7 +61,7 @@ The terminal should print public player state every turn:
 - **TC3: displayPublicPlayerState_WithActiveAndEliminatedPlayers_PrintsFaceDownAndFaceUpState**
     - **State of system**: One active player and one eliminated player with a killing kitten and remaining cards.
     - **Expected output**: Terminal prints active player's face-down card count and eliminated player's face-up killing kitten plus remaining face-up card types.
-    - **Implemented?** :x:
+    - **Implemented?** :white_check_mark:
 
 ---
 
@@ -78,4 +78,4 @@ The terminal should print public player state every turn:
 - **TC4: startTurn_DisplaysPublicPlayerStateThenCurrentPlayerHand**
     - **State of system**: Game has active players and may have eliminated player records.
     - **Expected output**: View displays public player state, then displays the current player's hand.
-    - **Implemented?** :x:
+    - **Implemented?** :white_check_mark:

--- a/src/main/java/domain/game/EliminatedPlayer.java
+++ b/src/main/java/domain/game/EliminatedPlayer.java
@@ -7,7 +7,7 @@ public final class EliminatedPlayer {
     private final Card killingKitten;
     private final List<Card> visibleCards;
 
-    EliminatedPlayer(String playerName, Card killingKitten, List<Card> visibleCards) {
+     public EliminatedPlayer(String playerName, Card killingKitten, List<Card> visibleCards) {
         this.playerName = playerName;
         this.killingKitten = killingKitten;
         this.visibleCards = List.copyOf(visibleCards);

--- a/src/main/java/domain/game/EliminatedPlayer.java
+++ b/src/main/java/domain/game/EliminatedPlayer.java
@@ -1,0 +1,31 @@
+package domain.game;
+
+import java.util.List;
+
+public final class EliminatedPlayer {
+    private final String playerName;
+    private final Card killingKitten;
+    private final List<Card> visibleCards;
+
+    EliminatedPlayer(String playerName, Card killingKitten, List<Card> visibleCards) {
+        this.playerName = playerName;
+        this.killingKitten = killingKitten;
+        this.visibleCards = List.copyOf(visibleCards);
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public Card getKillingKitten() {
+        return killingKitten;
+    }
+
+    public List<Card> getVisibleCards() {
+        return visibleCards;
+    }
+
+    public int getVisibleCardCount() {
+        return visibleCards.size();
+    }
+}

--- a/src/main/java/domain/game/Game.java
+++ b/src/main/java/domain/game/Game.java
@@ -30,6 +30,7 @@ public class Game {
     private int currentPlayerIndex;
     private int forcedTurns;
     private int direction = 1;
+    private final List<EliminatedPlayer> eliminatedPlayers;
 
     // Open to discussion: making Game final would avoid this warning, but controller tests currently mock it.
     @SuppressFBWarnings(
@@ -44,8 +45,9 @@ public class Game {
         this.discardPile = new DiscardPile();
         this.currentPlayerIndex = 0;
         this.forcedTurns = 0;
+        this.direction = 1;
+        this.eliminatedPlayers = new ArrayList<>();
     }
-
     public void setupGame(List<String> playerNames) {
         if (playerNames == null) {
             throw new IllegalArgumentException(PLAYER_NAMES_REQUIRED_MESSAGE);
@@ -76,6 +78,7 @@ public class Game {
         discardPile = new DiscardPile();
         currentPlayerIndex = 0;
         forcedTurns = 0;
+        eliminatedPlayers.clear();
     }
 
     public List<Player> getPlayers() {
@@ -204,5 +207,27 @@ public class Game {
 
     int getDirection() {
         return direction;
+    }
+
+    public void eliminatePlayer(Player player, Card killingKitten) {
+        List<Card> visibleCards = player.getHandSnapshot();
+        eliminatedPlayers.add(new EliminatedPlayer(
+                player.getName(),
+                killingKitten,
+                visibleCards));
+
+        int eliminatedIndex = players.indexOf(player);
+        players.remove(player);
+
+        while (player.getHandSize() > 0) {
+            player.removeCard(0);
+        }
+
+        if (!players.isEmpty() && eliminatedIndex <= currentPlayerIndex) {
+            currentPlayerIndex = currentPlayerIndex % players.size();
+        }
+    }
+    public List<EliminatedPlayer> getEliminatedPlayers() {
+        return List.copyOf(eliminatedPlayers);
     }
 }

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -96,7 +96,7 @@ public class GameController {
             if (defused) {
                 model.advanceTurn();
             } else {
-                model.eliminatePlayer(currentPlayer);
+                model.eliminatePlayer(currentPlayer, drawnCard);
                 if (model.isWon()) {
                     view.displayGameOver(model.getPlayers().get(0).getName());
                 }

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -36,6 +36,8 @@ public class GameController {
     }
 
     public void startTurn() {
+        view.displayPublicPlayerState(model.getPlayers(), model.getEliminatedPlayers());
+
         Player currentPlayer = model.getCurrentPlayer();
         view.displayHand(currentPlayer.getName(), currentPlayer.getHandSnapshot());
     }

--- a/src/main/java/ui/GameView.java
+++ b/src/main/java/ui/GameView.java
@@ -91,4 +91,30 @@ public class GameView {
         String message = MessageFormat.format(messages.getString("game.over.winner"), winnerName);
         System.out.println(message);
     }
+
+    public void displayPublicPlayerState(
+            List<Player> activePlayers,
+            List<EliminatedPlayer> eliminatedPlayers) {
+        System.out.println("Public player state:");
+
+        for (Player player : activePlayers) {
+            System.out.println(player.getName() + ": "
+                    + player.getHandSize() + " face-down card(s)");
+        }
+
+        for (EliminatedPlayer eliminatedPlayer : eliminatedPlayers) {
+            System.out.println(eliminatedPlayer.getPlayerName()
+                    + ": eliminated by face-up "
+                    + eliminatedPlayer.getKillingKitten().getType());
+
+            if (eliminatedPlayer.getVisibleCards().isEmpty()) {
+                System.out.println("Remaining face-up cards: none");
+            } else {
+                System.out.println("Remaining face-up cards:");
+                for (Card card : eliminatedPlayer.getVisibleCards()) {
+                    System.out.println("- " + card.getType());
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/ui/GameView.java
+++ b/src/main/java/ui/GameView.java
@@ -8,6 +8,8 @@ import java.util.ResourceBundle;
 import java.text.MessageFormat;
 
 import domain.game.Card;
+import domain.game.EliminatedPlayer;
+import domain.game.Player;
 
 public class GameView {
     private Scanner scanner;

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -178,28 +178,7 @@ public class GameControllerTest {
         verify(mockModel);
     }
 
-    @Test
-    void startTurn_DisplaysCurrentPlayerHand() {
-        Game mockModel = EasyMock.createMock(Game.class);
-        GameView mockView = EasyMock.createMock(GameView.class);
-        Player player = new Player("Sophie");
-        Card skip = new Card(CardType.SKIP);
-        Card beardCat = new Card(CardType.BEARD_CAT);
-        player.addCard(skip);
-        player.addCard(beardCat);
 
-        expect(mockModel.getCurrentPlayer()).andReturn(player).once();
-        replay(mockModel);
-        mockView.displayHand("Sophie", List.of(skip, beardCat));
-        expectLastCall().once();
-        replay(mockView);
-        GameController controller = new GameController(mockModel, mockView);
-
-        controller.startTurn();
-
-        verify(mockModel);
-        verify(mockView);
-    }
 
     @Test
     void completeTurn_NoCardsPlayed_DisplaysHandThenDrawsAndAdvances() {
@@ -211,6 +190,9 @@ public class GameControllerTest {
         clearDrawPile(game.getDrawPile());
         Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
         game.getDrawPile().addCard(drawnCard);
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
 
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
@@ -239,6 +221,10 @@ public class GameControllerTest {
         clearDrawPile(game.getDrawPile());
         game.getDrawPile().addCard(new Card(CardType.PLACEHOLDER_CARD));
         int drawPileSize = game.getDrawPile().size();
+
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
 
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
@@ -270,6 +256,10 @@ public class GameControllerTest {
         Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
         game.getDrawPile().addCard(secondFutureCard);
         game.getDrawPile().addCard(drawnCard);
+
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
 
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
@@ -305,6 +295,10 @@ public class GameControllerTest {
         Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
         game.getDrawPile().addCard(secondFutureCard);
         game.getDrawPile().addCard(drawnCard);
+
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
 
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
@@ -343,6 +337,10 @@ public class GameControllerTest {
         game.getDrawPile().addCard(drawnCardAfterShuffle);
         game.getDrawPile().addCard(remainingCardAfterDraw);
 
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
+
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
         mockView.displayCardDrawn(drawnCardAfterShuffle);
@@ -377,6 +375,10 @@ public class GameControllerTest {
         game.getDrawPile().addCard(bottomCard);
         game.getDrawPile().addCard(drawnCard);
         game.getDrawPile().addCard(buriedTopCard);
+
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
 
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
@@ -415,6 +417,10 @@ public class GameControllerTest {
         game.getDrawPile().addCard(topCard);
         int drawPileSize = game.getDrawPile().size();
 
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
+
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
         mockView.displaySeeTheFutureCards(List.of(topCard, secondFutureCard));
@@ -450,6 +456,10 @@ public class GameControllerTest {
         game.getDrawPile().addCard(new Card(CardType.PLACEHOLDER_CARD));
         int drawPileSize = game.getDrawPile().size();
 
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
+
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
         mockView.displayMessage("Skip played. Your turn ends without drawing a card.");
@@ -479,6 +489,10 @@ public class GameControllerTest {
         clearDrawPile(game.getDrawPile());
         Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
         game.getDrawPile().addCard(drawnCard);
+
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
 
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
@@ -511,6 +525,10 @@ public class GameControllerTest {
         Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
         game.getDrawPile().addCard(drawnCard);
 
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
+
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
         mockView.displayError("cardIndex is out of bounds");
@@ -542,6 +560,10 @@ public class GameControllerTest {
         Card drawnCard = new Card(CardType.PLACEHOLDER_CARD);
         game.getDrawPile().addCard(drawnCard);
 
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
+
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
         mockView.displayError("cardIndex is out of bounds");
@@ -572,6 +594,10 @@ public class GameControllerTest {
         clearDrawPile(game.getDrawPile());
         game.getDrawPile().addCard(new Card(CardType.PLACEHOLDER_CARD));
         int drawPileSize = game.getDrawPile().size();
+
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        EasyMock.expectLastCall().once();
 
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
@@ -1256,8 +1282,12 @@ public class GameControllerTest {
         game.getDrawPile().addCard(middleCard);
         game.getDrawPile().addCard(topCard);
 
-        mockView.displayHand("Sophie", startingHand);
+
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
         EasyMock.expectLastCall().once();
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
         mockView.displayCardDrawn(bottomCard);
         EasyMock.expectLastCall().once();
         EasyMock.replay(mockView);
@@ -1310,6 +1340,36 @@ public class GameControllerTest {
         assertEquals(List.of(remainingCard, secondRemainingCard), record.getVisibleCards());
 
         EasyMock.verify(mockView);
+    }
+
+    @Test
+    void startTurn_DisplaysPublicPlayerStateThenCurrentPlayerHand() {
+        Game mockModel = EasyMock.createMock(Game.class);
+        GameView mockView = EasyMock.createMock(GameView.class);
+
+        Player player = new Player("Sophie");
+        Card skip = new Card(CardType.SKIP);
+        player.addCard(skip);
+
+        List<Player> activePlayers = List.of(player);
+        List<EliminatedPlayer> eliminatedPlayers = List.of();
+
+        EasyMock.expect(mockModel.getPlayers()).andReturn(activePlayers).once();
+        EasyMock.expect(mockModel.getEliminatedPlayers()).andReturn(eliminatedPlayers).once();
+        EasyMock.expect(mockModel.getCurrentPlayer()).andReturn(player).once();
+
+        mockView.displayPublicPlayerState(activePlayers, eliminatedPlayers);
+        EasyMock.expectLastCall().once();
+        mockView.displayHand("Sophie", List.of(skip));
+        EasyMock.expectLastCall().once();
+
+        EasyMock.replay(mockModel, mockView);
+
+        GameController controller = new GameController(mockModel, mockView);
+
+        controller.startTurn();
+
+        EasyMock.verify(mockModel, mockView);
     }
 
     private Deck createDeckForPlayers(int playerCount) {

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -1274,6 +1274,44 @@ public class GameControllerTest {
         EasyMock.verify(mockView);
     }
 
+    @Test
+    void takeCard_ExplodingKittenWithoutDefuse_TracksEliminatedPlayer() {
+        Game game = new Game(createDeckForPlayers(2));
+        game.setupGame(List.of("Avery", "Jordan"));
+
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+
+        Card remainingCard = new Card(CardType.BEARD_CAT);
+        Card secondRemainingCard = new Card(CardType.SKIP);
+        currentPlayer.addCard(remainingCard);
+        currentPlayer.addCard(secondRemainingCard);
+
+        clearDrawPile(game.getDrawPile());
+        Card explodingKitten = new Card(CardType.EXPLODING_KITTEN);
+        game.getDrawPile().addCard(explodingKitten);
+
+        GameView mockView = EasyMock.createMock(GameView.class);
+        mockView.displayCardDrawn(explodingKitten);
+        EasyMock.expectLastCall().once();
+        mockView.displayGameOver("Jordan");
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(mockView);
+
+        GameController controller = new GameController(game, mockView);
+
+        controller.takeCard();
+
+        assertEquals(1, game.getEliminatedPlayers().size());
+
+        EliminatedPlayer record = game.getEliminatedPlayers().get(0);
+        assertEquals("Avery", record.getPlayerName());
+        assertEquals(explodingKitten, record.getKillingKitten());
+        assertEquals(List.of(remainingCard, secondRemainingCard), record.getVisibleCards());
+
+        EasyMock.verify(mockView);
+    }
+
     private Deck createDeckForPlayers(int playerCount) {
         return createDeckForPlayers(playerCount, new Random());
     }

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -371,6 +371,39 @@ class GameTest {
         assertEquals("Alice", game.getCurrentPlayer().getName());
     }
 
+    @Test
+    void eliminatePlayer_WithExplodingKitten_TracksFaceUpKittenAndRemainingCards() {
+        Game game = new Game(createDeck(1, 2, 10));
+        game.setupGame(List.of("Avery", "Jordan"));
+
+        Player eliminatedPlayer = game.getCurrentPlayer();
+        clearHand(eliminatedPlayer);
+
+        Card remainingCard = new Card(CardType.BEARD_CAT);
+        Card secondRemainingCard = new Card(CardType.SKIP);
+        eliminatedPlayer.addCard(remainingCard);
+        eliminatedPlayer.addCard(secondRemainingCard);
+
+        Card killingKitten = new Card(CardType.EXPLODING_KITTEN);
+
+        game.eliminatePlayer(eliminatedPlayer, killingKitten);
+
+        assertFalse(game.getPlayers().contains(eliminatedPlayer));
+        assertEquals(1, game.getEliminatedPlayers().size());
+
+        EliminatedPlayer record = game.getEliminatedPlayers().get(0);
+        assertEquals("Avery", record.getPlayerName());
+        assertEquals(killingKitten, record.getKillingKitten());
+        assertEquals(List.of(remainingCard, secondRemainingCard), record.getVisibleCards());
+        assertEquals(2, record.getVisibleCardCount());
+    }
+
+    private void clearHand(Player player) {
+        while (player.getHandSize() > 0) {
+            player.removeCard(0);
+        }
+    }
+
     private void assertPlayersHaveOpeningHands(List<Player> players) {
         for (Player player : players) {
             assertEquals(6, player.getHandSize());

--- a/src/test/java/ui/GameViewTest.java
+++ b/src/test/java/ui/GameViewTest.java
@@ -51,4 +51,42 @@ public class GameViewTest {
         assertTrue(text.contains("1. SKIP"));
         assertTrue(text.contains("2. BEARD_CAT"));
     }
+
+
+    @Test
+    void displayPublicPlayerState_WithActiveAndEliminatedPlayers_PrintsFaceDownAndFaceUpState() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
+
+        try {
+            GameView view = new GameView();
+
+            Player activePlayer = new Player("Jordan");
+            activePlayer.addCard(new Card(CardType.BEARD_CAT));
+            activePlayer.addCard(new Card(CardType.SKIP));
+
+            Card killingKitten = new Card(CardType.EXPLODING_KITTEN);
+            Card visibleCard = new Card(CardType.DEFUSE);
+            Card secondVisibleCard = new Card(CardType.TACOCAT);
+            EliminatedPlayer eliminatedPlayer = new EliminatedPlayer(
+                    "Avery",
+                    killingKitten,
+                    List.of(visibleCard, secondVisibleCard));
+
+            view.displayPublicPlayerState(
+                    List.of(activePlayer),
+                    List.of(eliminatedPlayer));
+
+            String printed = output.toString(StandardCharsets.UTF_8);
+
+            assertTrue(printed.contains("Jordan: 2 face-down card(s)"));
+            assertTrue(printed.contains("Avery: eliminated by face-up EXPLODING_KITTEN"));
+            assertTrue(printed.contains("Remaining face-up cards:"));
+            assertTrue(printed.contains("- DEFUSE"));
+            assertTrue(printed.contains("- TACOCAT"));
+        } finally {
+            System.setOut(originalOut);
+        }
+    }
 }

--- a/src/test/java/ui/GameViewTest.java
+++ b/src/test/java/ui/GameViewTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 import domain.game.Card;
 import domain.game.CardType;
+import domain.game.EliminatedPlayer;
+import domain.game.Player;
 import org.junit.jupiter.api.Test;
 
 public class GameViewTest {


### PR DESCRIPTION
Track eliminated players - ruleset says killing the kitten is face up in front of the dead player and the rest of their cards are face down. Current code only removes the player from active players i think
