### PR TITLE
Wip cherrypicked draw from bottom card

### DIFF
--- a/docs/bva/DrawFromBottomController.md
+++ b/docs/bva/DrawFromBottomController.md
@@ -5,14 +5,42 @@
 | Output: drawn card     | Object     | Values: <ul><li>throws `IllegalStateException`</li><li>returns the only card</li><li>returns bottom card not top card</li></ul> |
 
 - **Step 4:**
-    - **TC1: drawFromBottom_EmptyDeck_ThrowsIllegalStateException** (x: or :white_check_mark:)
+    - **TC1: drawFromBottom_EmptyDeck_ThrowsIllegalStateException** (:white_check_mark:)
         - **State of the system**: deck has no cards
         - **Expected output**: throws `IllegalStateException`
 
-    - **TC2: drawFromBottom_OneCard_ReturnsOnlyCard** (x: or :white_check_mark:)
+    - **TC2: drawFromBottom_OneCard_ReturnsOnlyCard** (:white_check_mark:)
         - **State of the system**: deck has one card (`SKIP`)
         - **Expected output**: returns `SKIP`, deck is now empty
 
-    - **TC3: drawFromBottom_MultipleCards_ReturnsBottomCard** (x: or :white_check_mark:)
+    - **TC3: drawFromBottom_MultipleCards_ReturnsBottomCard** ( :white_check_mark:)
         - **State of the system**: deck has `[SKIP, ATTACK]` where `SKIP` is at index 0 (bottom) and `ATTACK` is on top
         - **Expected output**: returns `SKIP`, `ATTACK` remains in deck
+
+### Method under test: `public Card play(Player player, int cardIndex)`
+| Step 1                        | Step 2     | Step 3                                                                                                                                    |
+|-------------------------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| Input 1: card index           | Integer    | Values: <ul><li>negative index</li><li>index equal to hand size</li><li>valid index pointing to `DRAW_FROM_BOTTOM`</li><li>valid index pointing to a non-`DRAW_FROM_BOTTOM` card</li></ul> |
+| Input 2: deck state           | Collection | Values: <ul><li>one card (non-exploding kitten)</li><li>one card (exploding kitten)</li></ul>                                            |
+| Output: drawn card / side effects | Object | Values: <ul><li>throws `IllegalArgumentException`</li><li>drawn card added to player hand and returned</li></ul>                         |
+
+- **Step 4:**
+    - **TC1: play_NegativeIndex_ThrowsIllegalArgumentException** (x: or :white_check_mark:)
+        - **State of the system**: player has one `DRAW_FROM_BOTTOM` card, card index is `-1`
+        - **Expected output**: throws `IllegalArgumentException`
+
+    - **TC2: play_IndexEqualsHandSize_ThrowsIllegalArgumentException** (x: or :white_check_mark:)
+        - **State of the system**: player has one `DRAW_FROM_BOTTOM` card, card index equals hand size
+        - **Expected output**: throws `IllegalArgumentException`
+
+    - **TC3: play_NotDrawFromBottomCard_ThrowsIllegalArgumentException** (x: or :white_check_mark:)
+        - **State of the system**: player has one `SKIP` card, card index is `0`
+        - **Expected output**: throws `IllegalArgumentException`
+
+    - **TC4: play_ValidCard_DrawsBottomCardIntoPlayerHand** (x: or :white_check_mark:)
+        - **State of the system**: player has one `DRAW_FROM_BOTTOM` card, deck has `[SKIP, ATTACK]` where `SKIP` is at the bottom
+        - **Expected output**: `DRAW_FROM_BOTTOM` removed from hand and added to discard, `SKIP` added to player hand, returns `SKIP`
+
+    - **TC5: play_ValidCard_ExplodingKittenDrawn_ReturnsExplodingKitten** (x: or :white_check_mark:)
+        - **State of the system**: player has one `DRAW_FROM_BOTTOM` card, deck has `[EXPLODING_KITTEN, ATTACK]` where `EXPLODING_KITTEN` is at the bottom
+        - **Expected output**: `DRAW_FROM_BOTTOM` discarded, `EXPLODING_KITTEN` added to player hand, returns `EXPLODING_KITTEN`

--- a/docs/bva/DrawFromBottomController.md
+++ b/docs/bva/DrawFromBottomController.md
@@ -1,0 +1,18 @@
+### Method under test: `public Card drawFromBottom()`
+| Step 1                 | Step 2     | Step 3                                                                                                          |
+|------------------------|------------|-----------------------------------------------------------------------------------------------------------------|
+| Input 1: deck state    | Collection | Values: <ul><li>empty deck</li><li>one card</li><li>more than one card</li></ul>                                |
+| Output: drawn card     | Object     | Values: <ul><li>throws `IllegalStateException`</li><li>returns the only card</li><li>returns bottom card not top card</li></ul> |
+
+- **Step 4:**
+    - **TC1: drawFromBottom_EmptyDeck_ThrowsIllegalStateException** (x: or :white_check_mark:)
+        - **State of the system**: deck has no cards
+        - **Expected output**: throws `IllegalStateException`
+
+    - **TC2: drawFromBottom_OneCard_ReturnsOnlyCard** (x: or :white_check_mark:)
+        - **State of the system**: deck has one card (`SKIP`)
+        - **Expected output**: returns `SKIP`, deck is now empty
+
+    - **TC3: drawFromBottom_MultipleCards_ReturnsBottomCard** (x: or :white_check_mark:)
+        - **State of the system**: deck has `[SKIP, ATTACK]` where `SKIP` is at index 0 (bottom) and `ATTACK` is on top
+        - **Expected output**: returns `SKIP`, `ATTACK` remains in deck

--- a/docs/bva/GameController.md
+++ b/docs/bva/GameController.md
@@ -129,3 +129,15 @@ private Game game;
 
 _Attack is now played through `completeTurn` (see TC12–TC14) and the forced-turn
 mechanics live in the `Game` model (`applyAttack` / `advanceTurn`); see `Game.md`._
+
+- **TC15: completeTurn_DrawFromBottomPlayed_DrawsBottomCardAndAdvances** (:x:white_check_mark:)
+  - **State of the system**: current player is `Sophie`, next player is `Jordan`, selected card index is `[0]`, card at index `0` is `DRAW_FROM_BOTTOM`, deck has `[SKIP, ATTACK]` where `SKIP` is at the bottom
+  - **Expected output**: `DRAW_FROM_BOTTOM` discarded, `SKIP` added to `Sophie`'s hand, turn advances to `Jordan`
+
+- **TC16: completeTurn_DrawFromBottomDrawsExplodingKittenWithDefuse_DefusesAndAdvances** (:x:white_check_mark:)
+    - **State of the system**: current player is `Sophie`, next player is `Jordan`, selected card index is `[0]`, card at index `0` is `DRAW_FROM_BOTTOM`, `Sophie` has a `DEFUSE`, deck has `[EXPLODING_KITTEN, ATTACK]` where `EXPLODING_KITTEN` is at the bottom
+    - **Expected output**: `DRAW_FROM_BOTTOM` discarded, `DEFUSE` discarded, `EXPLODING_KITTEN` returned to deck, turn advances to `Jordan`
+
+- **TC17: completeTurn_DrawFromBottomDrawsExplodingKittenWithoutDefuse_PlayerEliminated** (:x:white_check_mark:)
+    - **State of the system**: current player is `Sophie`, next player is `Jordan`, selected card index is `[0]`, card at index `0` is `DRAW_FROM_BOTTOM`, `Sophie` has no `DEFUSE`, deck has `[EXPLODING_KITTEN, ATTACK]` where `EXPLODING_KITTEN` is at the bottom
+    - **Expected output**: `DRAW_FROM_BOTTOM` discarded, `Sophie` is eliminated, `Jordan` is the only remaining player

--- a/src/main/java/domain/game/CardType.java
+++ b/src/main/java/domain/game/CardType.java
@@ -15,5 +15,6 @@ public enum CardType {
     SUPER_SKIP,
     REVERSE,
     BURY,
-    SWAP_TOP_AND_BOTTOM
+    SWAP_TOP_AND_BOTTOM,
+    DRAW_FROM_BOTTOM
 }

--- a/src/main/java/domain/game/Deck.java
+++ b/src/main/java/domain/game/Deck.java
@@ -116,7 +116,7 @@ public final class Deck {
 
 
 
-    public Card drawFromBottom(){
+    public Card drawFromBottom() {
         if (cards.isEmpty()) {
             throw new IllegalStateException(EMPTY_DECK_MESSAGE);
         }

--- a/src/main/java/domain/game/Deck.java
+++ b/src/main/java/domain/game/Deck.java
@@ -113,4 +113,14 @@ public final class Deck {
         cards.set(0, cards.get(topIndex));
         cards.set(topIndex, bottomCard);
     }
+
+
+
+    public Card drawFromBottom(){
+        if (cards.isEmpty()) {
+            throw new IllegalStateException(EMPTY_DECK_MESSAGE);
+        }
+        return cards.remove(0);
+    }
+
 }

--- a/src/main/java/domain/game/DrawFromBottomCardController.java
+++ b/src/main/java/domain/game/DrawFromBottomCardController.java
@@ -1,0 +1,26 @@
+package domain.game;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class DrawFromBottomCardController {
+    private static final String NOT_DRAW_FROM_BOTTOM_CARD_MESSAGE = "selected card is not a Draw from bottom card";
+    private static final String INVALID_INDEX_MESSAGE = "cardIndex is out of bounds";
+    private final Deck deck;
+    private final DiscardPile discardPile;
+
+
+    @SuppressFBWarnings("EI")
+    public DrawFromBottomCardController(Deck deck, DiscardPile discardPile) {
+        this.discardPile = discardPile;
+        this.deck = deck;
+    }
+
+    public Card play(Player player, int cardIndex){
+        if (cardIndex < 0 || cardIndex >= player.getHandSize()) {
+            throw new IllegalArgumentException(INVALID_INDEX_MESSAGE);
+        }
+        return new Card(CardType.PLACEHOLDER_CARD);
+
+    }
+
+}

--- a/src/main/java/domain/game/DrawFromBottomCardController.java
+++ b/src/main/java/domain/game/DrawFromBottomCardController.java
@@ -19,11 +19,18 @@ public class DrawFromBottomCardController {
         if (cardIndex < 0 || cardIndex >= player.getHandSize()) {
             throw new IllegalArgumentException(INVALID_INDEX_MESSAGE);
         }
+
         Card selectedCard = player.getHandSnapshot().get(cardIndex);
+
         if (selectedCard.getType() != CardType.DRAW_FROM_BOTTOM) {
             throw new IllegalArgumentException(NOT_DRAW_FROM_BOTTOM_CARD_MESSAGE);
         }
-        return new Card(CardType.PLACEHOLDER_CARD);
+
+        player.removeCard(cardIndex);
+        discardPile.add(selectedCard);
+        Card pulledCard = deck.drawFromBottom();
+        player.addCard(pulledCard);
+        return pulledCard;
 
     }
 

--- a/src/main/java/domain/game/DrawFromBottomCardController.java
+++ b/src/main/java/domain/game/DrawFromBottomCardController.java
@@ -19,6 +19,10 @@ public class DrawFromBottomCardController {
         if (cardIndex < 0 || cardIndex >= player.getHandSize()) {
             throw new IllegalArgumentException(INVALID_INDEX_MESSAGE);
         }
+        Card selectedCard = player.getHandSnapshot().get(cardIndex);
+        if (selectedCard.getType() != CardType.DRAW_FROM_BOTTOM) {
+            throw new IllegalArgumentException(NOT_DRAW_FROM_BOTTOM_CARD_MESSAGE);
+        }
         return new Card(CardType.PLACEHOLDER_CARD);
 
     }

--- a/src/main/java/domain/game/DrawFromBottomCardController.java
+++ b/src/main/java/domain/game/DrawFromBottomCardController.java
@@ -15,7 +15,7 @@ public class DrawFromBottomCardController {
         this.deck = deck;
     }
 
-    public Card play(Player player, int cardIndex){
+    public Card play(Player player, int cardIndex) {
         if (cardIndex < 0 || cardIndex >= player.getHandSize()) {
             throw new IllegalArgumentException(INVALID_INDEX_MESSAGE);
         }

--- a/src/main/java/domain/game/DrawFromBottomCardController.java
+++ b/src/main/java/domain/game/DrawFromBottomCardController.java
@@ -29,7 +29,6 @@ public class DrawFromBottomCardController {
         player.removeCard(cardIndex);
         discardPile.add(selectedCard);
         Card pulledCard = deck.drawFromBottom();
-        player.addCard(pulledCard);
         return pulledCard;
 
     }

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -74,6 +74,28 @@ public class GameController {
                 attackCardController.play(currentPlayer, cardIndex);
                 model.applyAttack();
                 return;
+            }if (selectedCard.getType() == CardType.DRAW_FROM_BOTTOM) {
+                DrawFromBottomCardController drawFromBottomCardController =
+                        new DrawFromBottomCardController(model.getDrawPile(), model.getDiscardPile());
+                Card drawnCard = drawFromBottomCardController.play(currentPlayer, cardIndex);
+                if (drawnCard.getType() == CardType.EXPLODING_KITTEN) {
+                    view.displayCardDrawn(drawnCard);
+                    ExplodingKittenCardController explodingKittenController =
+                            new ExplodingKittenCardController(model.getDrawPile(), model.getDiscardPile());
+                    boolean defused = explodingKittenController.play(currentPlayer, drawnCard);
+                    if (defused) {
+                        model.advanceTurn();
+                    } else {
+                        model.eliminatePlayer(currentPlayer);
+                        if (model.isWon()) {
+                            view.displayGameOver(model.getPlayers().get(0).getName());
+                        }
+                    }
+                    return;
+                }
+                view.displayCardDrawn(drawnCard);
+                model.advanceTurn();
+                return;
             }
 
             if (selectedCard.getType() == CardType.SWAP_TOP_AND_BOTTOM) {

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -74,7 +74,8 @@ public class GameController {
                 attackCardController.play(currentPlayer, cardIndex);
                 model.applyAttack();
                 return;
-            }if (selectedCard.getType() == CardType.DRAW_FROM_BOTTOM) {
+            }
+             if (selectedCard.getType() == CardType.DRAW_FROM_BOTTOM) {
                 DrawFromBottomCardController drawFromBottomCardController =
                         new DrawFromBottomCardController(model.getDrawPile(), model.getDiscardPile());
                 Card drawnCard = drawFromBottomCardController.play(currentPlayer, cardIndex);

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -89,13 +89,14 @@ public class GameController {
                     if (defused) {
                         model.advanceTurn();
                     } else {
-                        model.eliminatePlayer(currentPlayer);
+                        model.eliminatePlayer(currentPlayer, drawnCard);
                         if (model.isWon()) {
                             view.displayGameOver(model.getPlayers().get(0).getName());
                         }
                     }
                     return;
                 }
+                currentPlayer.addCard(drawnCard);
                 view.displayCardDrawn(drawnCard);
                 model.advanceTurn();
                 return;

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -184,4 +184,6 @@ public class GameController {
         }
     }
 
+
+
 }

--- a/src/test/java/domain/game/DeckTest.java
+++ b/src/test/java/domain/game/DeckTest.java
@@ -258,4 +258,13 @@ class DeckTest {
         assertEquals(0, deck.size());
     }
 
+    @Test
+    void drawFromBottom_MultipleCards_ReturnsBottomCard() {
+        Deck deck = new Deck(List.of(new Card(CardType.SKIP), new Card(CardType.ATTACK)));
+
+        Card drawn = deck.drawFromBottom();
+
+        assertEquals(CardType.SKIP, drawn.getType());
+        assertEquals(1, deck.size());
+    }
 }

--- a/src/test/java/domain/game/DeckTest.java
+++ b/src/test/java/domain/game/DeckTest.java
@@ -240,4 +240,12 @@ class DeckTest {
         EasyMock.replay(card);
         return card;
     }
+
+    @Test
+    void drawFromBottom_EmptyDeck_ThrowsIllegalStateException() {
+        Deck deck = new Deck(List.of());
+
+        assertThrows(IllegalStateException.class, () -> deck.drawFromBottom());
+    }
+
 }

--- a/src/test/java/domain/game/DeckTest.java
+++ b/src/test/java/domain/game/DeckTest.java
@@ -248,4 +248,14 @@ class DeckTest {
         assertThrows(IllegalStateException.class, () -> deck.drawFromBottom());
     }
 
+    @Test
+    void drawFromBottom_OneCard_ReturnsOnlyCard() {
+        Deck deck = new Deck(List.of(new Card(CardType.SKIP)));
+
+        Card drawn = deck.drawFromBottom();
+
+        assertEquals(CardType.SKIP, drawn.getType());
+        assertEquals(0, deck.size());
+    }
+
 }

--- a/src/test/java/domain/game/DrawFromBottomControllerTest.java
+++ b/src/test/java/domain/game/DrawFromBottomControllerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DrawFromBottomControllerTest {
@@ -39,5 +40,21 @@ public class DrawFromBottomControllerTest {
         DrawFromBottomCardController controller = new DrawFromBottomCardController(deck, discardPile);
 
         assertThrows(IllegalArgumentException.class, () -> controller.play(player, 0));
+    }
+
+    @Test
+    void play_ValidCard_DrawsBottomCardIntoPlayerHand() {
+        Player player = new Player("Sophie");
+        player.addCard(new Card(CardType.DRAW_FROM_BOTTOM));
+        Deck deck = new Deck(List.of(new Card(CardType.SKIP), new Card(CardType.ATTACK)));
+        DiscardPile discardPile = new DiscardPile();
+        DrawFromBottomCardController controller = new DrawFromBottomCardController(deck, discardPile);
+
+        Card drawn = controller.play(player, 0);
+
+        assertEquals(CardType.SKIP, drawn.getType());
+        assertEquals(1, player.getHandSize());
+        assertEquals(CardType.SKIP, player.getHandSnapshot().get(0).getType());
+        assertEquals(1, discardPile.size());
     }
 }

--- a/src/test/java/domain/game/DrawFromBottomControllerTest.java
+++ b/src/test/java/domain/game/DrawFromBottomControllerTest.java
@@ -57,4 +57,19 @@ public class DrawFromBottomControllerTest {
         assertEquals(CardType.SKIP, player.getHandSnapshot().get(0).getType());
         assertEquals(1, discardPile.size());
     }
+
+    @Test
+    void play_ValidCard_ExplodingKittenDrawn_ReturnsExplodingKitten() {
+        Player player = new Player("Sophie");
+        player.addCard(new Card(CardType.DRAW_FROM_BOTTOM));
+        Deck deck = new Deck(List.of(new Card(CardType.EXPLODING_KITTEN), new Card(CardType.ATTACK)));
+        DiscardPile discardPile = new DiscardPile();
+        DrawFromBottomCardController controller = new DrawFromBottomCardController(deck, discardPile);
+
+        Card drawn = controller.play(player, 0);
+
+        assertEquals(CardType.EXPLODING_KITTEN, drawn.getType());
+        assertEquals(1, player.getHandSize());
+        assertEquals(CardType.EXPLODING_KITTEN, player.getHandSnapshot().get(0).getType());
+    }
 }

--- a/src/test/java/domain/game/DrawFromBottomControllerTest.java
+++ b/src/test/java/domain/game/DrawFromBottomControllerTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DrawFromBottomControllerTest {
+
     @Test
     void play_NegativeIndex_ThrowsIllegalArgumentException() {
         Player player = new Player("Sophie");
@@ -16,5 +17,16 @@ public class DrawFromBottomControllerTest {
         DrawFromBottomCardController controller = new DrawFromBottomCardController(deck, discardPile);
 
         assertThrows(IllegalArgumentException.class, () -> controller.play(player, -1));
+    }
+
+    @Test
+    void play_IndexEqualsHandSize_ThrowsIllegalArgumentException() {
+        Player player = new Player("Sophie");
+        player.addCard(new Card(CardType.DRAW_FROM_BOTTOM));
+        Deck deck = new Deck(List.of(new Card(CardType.SKIP)));
+        DiscardPile discardPile = new DiscardPile();
+        DrawFromBottomCardController controller = new DrawFromBottomCardController(deck, discardPile);
+
+        assertThrows(IllegalArgumentException.class, () -> controller.play(player, player.getHandSize()));
     }
 }

--- a/src/test/java/domain/game/DrawFromBottomControllerTest.java
+++ b/src/test/java/domain/game/DrawFromBottomControllerTest.java
@@ -29,4 +29,15 @@ public class DrawFromBottomControllerTest {
 
         assertThrows(IllegalArgumentException.class, () -> controller.play(player, player.getHandSize()));
     }
+
+    @Test
+    void play_NotDrawFromBottomCard_ThrowsIllegalArgumentException() {
+        Player player = new Player("Sophie");
+        player.addCard(new Card(CardType.SKIP));
+        Deck deck = new Deck(List.of(new Card(CardType.SKIP)));
+        DiscardPile discardPile = new DiscardPile();
+        DrawFromBottomCardController controller = new DrawFromBottomCardController(deck, discardPile);
+
+        assertThrows(IllegalArgumentException.class, () -> controller.play(player, 0));
+    }
 }

--- a/src/test/java/domain/game/DrawFromBottomControllerTest.java
+++ b/src/test/java/domain/game/DrawFromBottomControllerTest.java
@@ -1,0 +1,20 @@
+package domain.game;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DrawFromBottomControllerTest {
+    @Test
+    void play_NegativeIndex_ThrowsIllegalArgumentException() {
+        Player player = new Player("Sophie");
+        player.addCard(new Card(CardType.DRAW_FROM_BOTTOM));
+        Deck deck = new Deck(List.of(new Card(CardType.SKIP)));
+        DiscardPile discardPile = new DiscardPile();
+        DrawFromBottomCardController controller = new DrawFromBottomCardController(deck, discardPile);
+
+        assertThrows(IllegalArgumentException.class, () -> controller.play(player, -1));
+    }
+}

--- a/src/test/java/domain/game/DrawFromBottomControllerTest.java
+++ b/src/test/java/domain/game/DrawFromBottomControllerTest.java
@@ -53,8 +53,7 @@ public class DrawFromBottomControllerTest {
         Card drawn = controller.play(player, 0);
 
         assertEquals(CardType.SKIP, drawn.getType());
-        assertEquals(1, player.getHandSize());
-        assertEquals(CardType.SKIP, player.getHandSnapshot().get(0).getType());
+        assertEquals(0, player.getHandSize());
         assertEquals(1, discardPile.size());
     }
 
@@ -69,7 +68,6 @@ public class DrawFromBottomControllerTest {
         Card drawn = controller.play(player, 0);
 
         assertEquals(CardType.EXPLODING_KITTEN, drawn.getType());
-        assertEquals(1, player.getHandSize());
-        assertEquals(CardType.EXPLODING_KITTEN, player.getHandSnapshot().get(0).getType());
+        assertEquals(0, player.getHandSize());
     }
 }

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -1322,6 +1322,8 @@ public class GameControllerTest {
         game.getDrawPile().addCard(bottomCard);
         game.getDrawPile().addCard(topCard);
 
+        mockView.displayPublicPlayerState(game.getPlayers(), game.getEliminatedPlayers());
+        expectLastCall().once();
         mockView.displayHand("Sophie", startingHand);
         expectLastCall().once();
         mockView.displayCardDrawn(bottomCard);
@@ -1337,6 +1339,8 @@ public class GameControllerTest {
         assertEquals(1, game.getDrawPile().size());
         assertEquals("Jordan", game.getCurrentPlayer().getName());
         verify(mockView);
+    }
+
     @Test
     void takeCard_ExplodingKittenWithoutDefuse_TracksEliminatedPlayer() {
         Game game = new Game(createDeckForPlayers(2));

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -1274,6 +1274,41 @@ public class GameControllerTest {
         EasyMock.verify(mockView);
     }
 
+
+
+  @Test
+    void completeTurn_DrawFromBottomPlayed_DrawsBottomCardAndAdvances() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        Card drawFromBottom = new Card(CardType.DRAW_FROM_BOTTOM);
+        currentPlayer.addCard(drawFromBottom);
+        List<Card> startingHand = currentPlayer.getHandSnapshot();
+        clearDrawPile(game.getDrawPile());
+        Card bottomCard = new Card(CardType.SKIP);
+        Card topCard = new Card(CardType.ATTACK);
+        game.getDrawPile().addCard(bottomCard);
+        game.getDrawPile().addCard(topCard);
+
+        mockView.displayHand("Sophie", startingHand);
+        expectLastCall().once();
+        mockView.displayCardDrawn(bottomCard);
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.completeTurn(List.of(0));
+
+        assertEquals(1, currentPlayer.getHandSize());
+        assertEquals(CardType.SKIP, currentPlayer.getHandSnapshot().get(0).getType());
+        assertEquals(List.of(drawFromBottom), game.getDiscardPile().snapshot());
+        assertEquals(1, game.getDrawPile().size());
+        assertEquals("Jordan", game.getCurrentPlayer().getName());
+        verify(mockView);
+    }
+
     private Deck createDeckForPlayers(int playerCount) {
         return createDeckForPlayers(playerCount, new Random());
     }


### PR DESCRIPTION
Original PR (WIP-DrawFromBottomCard): Implemented the Draw from Bottom card — added Deck.drawFromBottom(), DrawFromBottomCardController, and wired the card into GameController.completeTurn. Included full BVA analysis and TDD test coverage.

This PR (WIP-cherrypicked-DrawFromBottomCard): Re-opens the same work as a clean branch after the original PR had unresolvable merge conflicts from a bad conflict resolution in CardType.java and GameController.java. Cherry-picked only the feature commits, skipping the broken merge commit