### PR TITLE
Fix Defuse reinsertion and eliminated-player secrecy

### DIFF
--- a/docs/bva/Deck.md
+++ b/docs/bva/Deck.md
@@ -31,6 +31,16 @@
 | `DECK-ADD-1` | Empty deck, add a non-null card. | Deck size increases from `0` to `1`. | :white_check_mark: |
 | `DECK-ADD-2` | Any deck state, add `null`. | Throw `IllegalArgumentException` with message `card must not be null`. | :white_check_mark: |
 
+## Method under test: `public void insertCard(Card card, int positionFromTop)`
+
+Position `0` is the top of the draw pile. Position `size` is the bottom.
+
+| ID | State of the system | Expected output | Implemented? |
+| --- | --- | --- | --- |
+| `DECK-INSERT-1` | Multi-card deck; insert at a middle position. | Insert relative to the top without changing the order of the existing cards. | :white_check_mark: |
+| `DECK-INSERT-2` | Insert at position less than `0`. | Throw `IllegalArgumentException` with the valid-range message. | :white_check_mark: |
+| `DECK-INSERT-3` | Insert at position greater than `size`. | Throw `IllegalArgumentException` with the valid-range message. | :white_check_mark: |
+
 ## Method under test: `public List<Card> removeCardsByType(CardType type)`
 
 | ID | State of the system | Expected output | Implemented? |

--- a/docs/bva/EliminatedPlayers.md
+++ b/docs/bva/EliminatedPlayers.md
@@ -4,11 +4,15 @@
 
 ## Rule
 
-When a player draws an Exploding Kitten and cannot Defuse it, that player is eliminated from the active player list. The killing Exploding Kitten should be shown face up in front of the eliminated player. The eliminated player's remaining hand cards should also be visible by card type.
+When a player draws an Exploding Kitten and cannot Defuse it, that player is
+eliminated from the active player list. The killing Exploding Kitten is shown
+face up in front of the eliminated player. All remaining hand cards stay face
+down, so only their count is public.
 
 The terminal should print public player state every turn:
 - Active players are shown with face-down card counts.
-- Eliminated players are shown with the face-up killing Exploding Kitten and their remaining face-up card types.
+- Eliminated players are shown with the face-up killing Exploding Kitten and
+  the count of their remaining face-down cards.
 
 ---
 
@@ -19,13 +23,14 @@ The terminal should print public player state every turn:
 | Step 1 | active player count | Collection size | 2 players; more than 2 players |
 | Step 2 | eliminated player hand | Collection size | empty hand; one card; more than one card |
 | Step 3 | killing card | Card type | `EXPLODING_KITTEN` |
-| Step 4 | output/state change | Collection state | player removed from active players; eliminated player record added; killing kitten stored face up; remaining hand cards stored face up by type |
+| Step 4 | output/state change | Collection state | player removed from active players; eliminated player record added; killing kitten stored face up; remaining hand stored only as a face-down card count |
 
 ### Test Cases
 
-- **TC1: eliminatePlayer_WithExplodingKitten_TracksFaceUpKittenAndRemainingCards**
+- **TC1: eliminatePlayer_WithExplodingKitten_TracksFaceUpKittenAndFaceDownCardCount**
     - **State of system**: Current player has remaining cards and is eliminated by an Exploding Kitten.
-    - **Expected output**: Player is removed from active players. Eliminated player record stores the killing kitten and the remaining card types.
+    - **Expected output**: Player is removed from active players. The record
+      stores the killing kitten and remaining hand size, but not the card types.
     - **Implemented?** :white_check_mark:
 
 ---
@@ -36,13 +41,14 @@ The terminal should print public player state every turn:
 |---|---|---|---|
 | Step 1 | drawn card | Card type | `EXPLODING_KITTEN` |
 | Step 2 | current player hand | Collection state | no Defuse; has remaining non-Defuse cards |
-| Step 3 | output/state change | Controller/model integration | current player is eliminated; killing kitten and remaining cards are recorded |
+| Step 3 | output/state change | Controller/model integration | current player is eliminated; killing kitten and remaining face-down card count are recorded |
 
 ### Test Cases
 
 - **TC2: takeCard_ExplodingKittenWithoutDefuse_TracksEliminatedPlayer**
     - **State of system**: Current player draws an Exploding Kitten without a Defuse and has remaining cards.
-    - **Expected output**: GameController records the eliminated player with the drawn Exploding Kitten face up and the remaining hand cards face up by type.
+    - **Expected output**: GameController records the drawn Exploding Kitten
+      face up and only the count of the remaining face-down cards.
     - **Implemented?** :white_check_mark:
 
 ---
@@ -53,14 +59,16 @@ The terminal should print public player state every turn:
 |---|---|---|---|
 | Step 1 | active players | Collection size | one or more active players |
 | Step 2 | eliminated players | Collection size | no eliminated players; one eliminated player; multiple eliminated players |
-| Step 3 | eliminated player visible cards | Collection size | empty visible hand; one visible card; multiple visible cards |
-| Step 4 | output | Terminal display | active players shown with face-down card counts; eliminated players shown with face-up killing kitten and face-up remaining card types |
+| Step 3 | eliminated player face-down count | Integer boundary | 0 cards; 1 card; more than 1 card |
+| Step 4 | output | Terminal display | active players shown with face-down card counts; eliminated players shown with face-up killing kitten and remaining face-down count; no hidden card types printed |
 
 ### Test Cases
 
-- **TC3: displayPublicPlayerState_WithActiveAndEliminatedPlayers_PrintsFaceDownAndFaceUpState**
+- **TC3: displayPublicPlayerState_WithEliminatedPlayer_HidesRemainingCardTypes**
     - **State of system**: One active player and one eliminated player with a killing kitten and remaining cards.
-    - **Expected output**: Terminal prints active player's face-down card count and eliminated player's face-up killing kitten plus remaining face-up card types.
+    - **Expected output**: Terminal prints the active player's face-down card
+      count, the eliminated player's face-up killing kitten, and the remaining
+      face-down count. It does not print the remaining card types.
     - **Implemented?** :white_check_mark:
 
 ---

--- a/docs/bva/ExplodingKittenCardController.md
+++ b/docs/bva/ExplodingKittenCardController.md
@@ -1,10 +1,16 @@
 # BVA Analysis for Exploding Kitten Cards
 
-The rules say that a player who draws an `EXPLODING_KITTEN` explodes unless they can play a `DEFUSE`. If they do play a `DEFUSE`, the `DEFUSE` goes to the discard pile and the drawn `EXPLODING_KITTEN` is returned to the draw pile. Player elimination and game-over checks are game-flow responsibilities, so this controller reports whether the kitten was defused and only mutates the draw pile, discard pile, and player hand for the card effect.
+The rules say that a player who draws an `EXPLODING_KITTEN` explodes unless
+they can play a `DEFUSE`. If they do, the `DEFUSE` goes to the discard pile and
+the player secretly returns the kitten anywhere in the draw pile. Position `0`
+is the top (the next draw), and position `drawPile.size()` is the bottom.
+Player elimination and game-over checks remain game-flow responsibilities.
 
-This BVA uses each-choice coverage over the catalog values below. The current domain model can test Defuse removal, discard pile changes, and draw pile reinsertion; it does not yet model the secret placement UI or face-up/dead-player pile.
+The terminal tells all other players to look away before asking for the
+position. It validates the choice before passing it to the controller. A
+successful Defuse still ends the current turn.
 
-## Method under test: `ExplodingKittenCardController.play(Player player, Card explodingKitten)`
+## Method under test: `ExplodingKittenCardController.play(Player, Card, int)`
 
 | Step 1 | Step 2 | Step 3 |
 |---|---|---|
@@ -13,7 +19,8 @@ This BVA uses each-choice coverage over the catalog values below. The current do
 | Input 3: player's `DEFUSE` subset | Collection Subset | Values: <ul><li>Subset is empty because the hand is empty</li><li>Subset is empty while the hand is not empty</li><li>Subset contains exactly one `DEFUSE`</li><li>Subset contains all but one card in the hand</li><li>Subset is the same as the whole hand</li></ul> |
 | Input 4: draw pile before reinserting the kitten | Collection Size | Values: <ul><li>Draw pile is empty</li><li>Draw pile has exactly 1 card</li><li>Draw pile has more than 1 card</li></ul> |
 | Input 5: discard pile before discarding `DEFUSE` | Collection Size | Values: <ul><li>Discard pile is empty</li><li>Discard pile is not empty</li></ul> |
-| Output | Boolean / State Change / Exception | Values: <ul><li>Returns `false` when the player has no `DEFUSE`</li><li>Returns `true` when the player defuses</li><li>Removes exactly 1 `DEFUSE` from the player hand</li><li>Adds exactly 1 `DEFUSE` to the discard pile</li><li>Returns the drawn `EXPLODING_KITTEN` to the draw pile</li><li>Leaves non-Defuse hand cards with the player</li><li>Throws exception for invalid inputs</li></ul> |
+| Input 6: insertion position from top | Integer Boundary | Values: <ul><li>`0` (top)</li><li>`1..size - 1` (middle)</li><li>`size` (bottom)</li><li>less than `0`</li><li>greater than `size`</li></ul> |
+| Output | Boolean / State Change / Exception | Values: <ul><li>Returns `false` when the player has no `DEFUSE`</li><li>Returns `true` when the player defuses</li><li>Removes exactly 1 `DEFUSE` from the player hand</li><li>Adds exactly 1 `DEFUSE` to the discard pile</li><li>Returns the drawn `EXPLODING_KITTEN` at the selected position</li><li>Leaves non-Defuse hand cards with the player</li><li>Throws exception for invalid inputs</li></ul> |
 
 ### Test Cases
 
@@ -40,3 +47,19 @@ This BVA uses each-choice coverage over the catalog values below. The current do
 - **TC10: play_DrawnCardIsNotExplodingKitten_ThrowsException** (:white_check_mark:)
     - **State of system**: Current player is valid; drawn card = `DEFUSE`.
     - **Expected output**: `IllegalArgumentException` thrown.
+
+- **TC11: play_DefuseWithMiddlePosition_ReinsertsKittenAtSelectedPosition** (:white_check_mark:)
+    - **State of system**: Draw pile has a top and bottom card; insertion position is `1`.
+    - **Expected output**: The kitten is inserted between those cards.
+
+- **TC12: promptDefuseInsertionPosition_BottomPosition_ReturnsChoiceAndWarnsOtherPlayers** (:white_check_mark:)
+    - **State of system**: Draw pile size and entered position are both `3`.
+    - **Expected output**: The terminal tells other players to look away and accepts the bottom position.
+
+- **TC13: promptDefuseInsertionPosition_OutOfRangeThenValid_ReturnsValidChoice** (:white_check_mark:)
+    - **State of system**: Player first enters `-1`, then a valid position.
+    - **Expected output**: The terminal rejects the invalid value and returns the valid one.
+
+- **TC14: takeCard_ExplodingKittenWithDefuse_ReinsertsKittenAtSelectedPosition** (:white_check_mark:)
+    - **State of system**: The current player has a `DEFUSE` and selects a middle position.
+    - **Expected output**: The kitten is placed at that position and play advances to the next player.

--- a/src/main/java/domain/game/Deck.java
+++ b/src/main/java/domain/game/Deck.java
@@ -13,6 +13,8 @@ public final class Deck {
     private static final String CARD_TYPE_REQUIRED_MESSAGE = "card type must not be null";
     private static final String EMPTY_DECK_MESSAGE = "cannot draw from an empty deck";
     private static final String NEGATIVE_COUNT_MESSAGE = "count must not be negative";
+    private static final String INVALID_POSITION_MESSAGE =
+            "position must be between 0 and deck size";
 
     private final List<Card> cards;
     private final Random random;
@@ -53,6 +55,9 @@ public final class Deck {
     }
 
     public void insertCard(Card card, int positionFromTop) {
+        if (positionFromTop < 0) {
+            throw new IllegalArgumentException(INVALID_POSITION_MESSAGE);
+        }
         cards.add(cards.size() - positionFromTop, card);
     }
 

--- a/src/main/java/domain/game/Deck.java
+++ b/src/main/java/domain/game/Deck.java
@@ -55,7 +55,7 @@ public final class Deck {
     }
 
     public void insertCard(Card card, int positionFromTop) {
-        if (positionFromTop < 0) {
+        if (positionFromTop < 0 || positionFromTop > cards.size()) {
             throw new IllegalArgumentException(INVALID_POSITION_MESSAGE);
         }
         cards.add(cards.size() - positionFromTop, card);

--- a/src/main/java/domain/game/Deck.java
+++ b/src/main/java/domain/game/Deck.java
@@ -52,6 +52,10 @@ public final class Deck {
         cards.add(card);
     }
 
+    public void insertCard(Card card, int positionFromTop) {
+        cards.add(cards.size() - positionFromTop, card);
+    }
+
     public void moveTopToBottom() {
         if (cards.isEmpty()) {
             return;

--- a/src/main/java/domain/game/EliminatedPlayer.java
+++ b/src/main/java/domain/game/EliminatedPlayer.java
@@ -1,16 +1,14 @@
 package domain.game;
 
-import java.util.List;
-
 public final class EliminatedPlayer {
     private final String playerName;
     private final Card killingKitten;
-    private final List<Card> visibleCards;
+    private final int faceDownCardCount;
 
-     public EliminatedPlayer(String playerName, Card killingKitten, List<Card> visibleCards) {
+    public EliminatedPlayer(String playerName, Card killingKitten, int faceDownCardCount) {
         this.playerName = playerName;
         this.killingKitten = killingKitten;
-        this.visibleCards = List.copyOf(visibleCards);
+        this.faceDownCardCount = faceDownCardCount;
     }
 
     public String getPlayerName() {
@@ -21,11 +19,7 @@ public final class EliminatedPlayer {
         return killingKitten;
     }
 
-    public List<Card> getVisibleCards() {
-        return visibleCards;
-    }
-
-    public int getVisibleCardCount() {
-        return visibleCards.size();
+    public int getFaceDownCardCount() {
+        return faceDownCardCount;
     }
 }

--- a/src/main/java/domain/game/ExplodingKittenCardController.java
+++ b/src/main/java/domain/game/ExplodingKittenCardController.java
@@ -23,6 +23,10 @@ public final class ExplodingKittenCardController {
     }
 
     public boolean play(Player player, Card explodingKitten) {
+        return play(player, explodingKitten, 0);
+    }
+
+    public boolean play(Player player, Card explodingKitten, int positionFromTop) {
         if (explodingKitten.getType() != CardType.EXPLODING_KITTEN) {
             throw new IllegalArgumentException(EXPLODING_KITTEN_TYPE_REQUIRED_MESSAGE);
         }
@@ -34,7 +38,7 @@ public final class ExplodingKittenCardController {
         Card defuse = player.getHandSnapshot().get(defuseIndex);
         player.removeCard(defuseIndex);
         discardPile.add(defuse);
-        drawPile.addCard(explodingKitten);
+        drawPile.insertCard(explodingKitten, positionFromTop);
         return true;
     }
 

--- a/src/main/java/domain/game/ExplodingKittenCardController.java
+++ b/src/main/java/domain/game/ExplodingKittenCardController.java
@@ -22,10 +22,6 @@ public final class ExplodingKittenCardController {
         this.discardPile = discardPile;
     }
 
-    public boolean play(Player player, Card explodingKitten) {
-        return play(player, explodingKitten, 0);
-    }
-
     public boolean play(Player player, Card explodingKitten, int positionFromTop) {
         if (explodingKitten.getType() != CardType.EXPLODING_KITTEN) {
             throw new IllegalArgumentException(EXPLODING_KITTEN_TYPE_REQUIRED_MESSAGE);

--- a/src/main/java/domain/game/Game.java
+++ b/src/main/java/domain/game/Game.java
@@ -226,11 +226,10 @@ public class Game {
     }
 
     public void eliminatePlayer(Player player, Card killingKitten) {
-        List<Card> visibleCards = player.getHandSnapshot();
         eliminatedPlayers.add(new EliminatedPlayer(
                 player.getName(),
                 killingKitten,
-                visibleCards));
+                player.getHandSize()));
 
         int eliminatedIndex = players.indexOf(player);
         boolean currentPlayerEliminated = eliminatedIndex == currentPlayerIndex;

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -199,7 +199,12 @@ public class GameController {
         view.displayCardDrawn(drawnCard);
         ExplodingKittenCardController explodingKittenController =
                 new ExplodingKittenCardController(model.getDrawPile(), model.getDiscardPile());
-        boolean defused = explodingKittenController.play(currentPlayer, drawnCard);
+        int insertionPosition = 0;
+        if (currentPlayer.countCardsOfType(CardType.DEFUSE) > 0) {
+            insertionPosition = view.promptDefuseInsertionPosition(model.getDrawPile().size());
+        }
+        boolean defused = explodingKittenController.play(
+                currentPlayer, drawnCard, insertionPosition);
         if (defused) {
             model.advanceTurn();
             return;

--- a/src/main/java/ui/GameView.java
+++ b/src/main/java/ui/GameView.java
@@ -159,14 +159,8 @@ public class GameView {
                     + ": eliminated by face-up "
                     + eliminatedPlayer.getKillingKitten().getType());
 
-            if (eliminatedPlayer.getVisibleCards().isEmpty()) {
-                System.out.println("Remaining face-up cards: none");
-            } else {
-                System.out.println("Remaining face-up cards:");
-                for (Card card : eliminatedPlayer.getVisibleCards()) {
-                    System.out.println("- " + card.getType());
-                }
-            }
+            System.out.println("Remaining face-down cards: "
+                    + eliminatedPlayer.getVisibleCardCount());
         }
     }
 

--- a/src/main/java/ui/GameView.java
+++ b/src/main/java/ui/GameView.java
@@ -64,6 +64,13 @@ public class GameView {
         return readInteger("turn.second.card.prompt");
     }
 
+    public int promptDefuseInsertionPosition(int drawPileSize) {
+        System.out.println(messages.getString("defuse.look.away"));
+        String prompt = MessageFormat.format(
+                messages.getString("defuse.position.prompt"), drawPileSize);
+        return readIntegerPrompt(prompt);
+    }
+
     public void displayGameReady() {
         System.out.println(messages.getString("game.ready.message"));
     }
@@ -165,8 +172,12 @@ public class GameView {
     }
 
     private int readInteger(String promptKey) {
+        return readIntegerPrompt(messages.getString(promptKey));
+    }
+
+    private int readIntegerPrompt(String prompt) {
         while (true) {
-            System.out.print(messages.getString(promptKey));
+            System.out.print(prompt);
             if (scanner.hasNextInt()) {
                 int choice = scanner.nextInt();
                 scanner.nextLine();

--- a/src/main/java/ui/GameView.java
+++ b/src/main/java/ui/GameView.java
@@ -160,7 +160,7 @@ public class GameView {
                     + eliminatedPlayer.getKillingKitten().getType());
 
             System.out.println("Remaining face-down cards: "
-                    + eliminatedPlayer.getVisibleCardCount());
+                    + eliminatedPlayer.getFaceDownCardCount());
         }
     }
 

--- a/src/main/java/ui/GameView.java
+++ b/src/main/java/ui/GameView.java
@@ -68,7 +68,15 @@ public class GameView {
         System.out.println(messages.getString("defuse.look.away"));
         String prompt = MessageFormat.format(
                 messages.getString("defuse.position.prompt"), drawPileSize);
-        return readIntegerPrompt(prompt);
+        while (true) {
+            int position = readIntegerPrompt(prompt);
+            if (position >= 0 && position <= drawPileSize) {
+                return position;
+            }
+            String error = MessageFormat.format(
+                    messages.getString("defuse.position.invalid"), drawPileSize);
+            System.out.println(error);
+        }
     }
 
     public void displayGameReady() {

--- a/src/main/resources/message_de.properties
+++ b/src/main/resources/message_de.properties
@@ -9,6 +9,8 @@ target.player.choice=Gib die Zielnummer ein:
 target.player.invalid=Wähle eine Zahl zwischen 1 und {0}.
 turn.card.prompt=Gib eine Kartennummer zum Spielen ein oder 0 zum Ziehen: 
 turn.second.card.prompt=Gib die Nummer der zweiten passenden Karte ein: 
+defuse.look.away=Alle außer dem aktuellen Spieler: Schaut jetzt weg.
+defuse.position.prompt=Wähle geheim eine Position von 0 (oben) bis {0} (unten):\u0020
 input.integer.error=Bitte gib eine Zahl ein.
 
 game.ready.message=Das Spiel ist bereit! Los geht’s!

--- a/src/main/resources/message_de.properties
+++ b/src/main/resources/message_de.properties
@@ -11,6 +11,7 @@ turn.card.prompt=Gib eine Kartennummer zum Spielen ein oder 0 zum Ziehen:
 turn.second.card.prompt=Gib die Nummer der zweiten passenden Karte ein: 
 defuse.look.away=Alle außer dem aktuellen Spieler: Schaut jetzt weg.
 defuse.position.prompt=Wähle geheim eine Position von 0 (oben) bis {0} (unten):\u0020
+defuse.position.invalid=Wähle eine Position zwischen 0 und {0}.
 input.integer.error=Bitte gib eine Zahl ein.
 
 game.ready.message=Das Spiel ist bereit! Los geht’s!

--- a/src/main/resources/message_en.properties
+++ b/src/main/resources/message_en.properties
@@ -11,6 +11,7 @@ turn.card.prompt=Enter a card number to play, or 0 to draw:
 turn.second.card.prompt=Enter the second matching card number: 
 defuse.look.away=Everyone except the current player: look away now.
 defuse.position.prompt=Secretly choose a position from 0 (top) to {0} (bottom):\u0020
+defuse.position.invalid=Choose a position between 0 and {0}.
 input.integer.error=Please enter a number.
 
 game.ready.message=Game is ready! Let's begin!

--- a/src/main/resources/message_en.properties
+++ b/src/main/resources/message_en.properties
@@ -9,6 +9,8 @@ target.player.choice=Enter target number:
 target.player.invalid=Choose a number between 1 and {0}.
 turn.card.prompt=Enter a card number to play, or 0 to draw: 
 turn.second.card.prompt=Enter the second matching card number: 
+defuse.look.away=Everyone except the current player: look away now.
+defuse.position.prompt=Secretly choose a position from 0 (top) to {0} (bottom):\u0020
 input.integer.error=Please enter a number.
 
 game.ready.message=Game is ready! Let's begin!

--- a/src/test/java/domain/game/DeckTest.java
+++ b/src/test/java/domain/game/DeckTest.java
@@ -131,6 +131,17 @@ class DeckTest {
     }
 
     @Test
+    void insertCard_NegativePosition_ThrowsException() {
+        Deck deck = new Deck(List.of(new Card(CardType.SKIP)));
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> deck.insertCard(new Card(CardType.EXPLODING_KITTEN), -1));
+
+        assertEquals("position must be between 0 and deck size", exception.getMessage());
+    }
+
+    @Test
     void removeCardsByTypeReturnsEmptyListWhenTypeIsAbsent() {
         Card firstCard = createCardWithType(CardType.PLACEHOLDER_CARD);
         Card secondCard = createCardWithType(CardType.DEFUSE);

--- a/src/test/java/domain/game/DeckTest.java
+++ b/src/test/java/domain/game/DeckTest.java
@@ -142,6 +142,17 @@ class DeckTest {
     }
 
     @Test
+    void insertCard_PositionPastBottom_ThrowsException() {
+        Deck deck = new Deck(List.of(new Card(CardType.SKIP)));
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> deck.insertCard(new Card(CardType.EXPLODING_KITTEN), 2));
+
+        assertEquals("position must be between 0 and deck size", exception.getMessage());
+    }
+
+    @Test
     void removeCardsByTypeReturnsEmptyListWhenTypeIsAbsent() {
         Card firstCard = createCardWithType(CardType.PLACEHOLDER_CARD);
         Card secondCard = createCardWithType(CardType.DEFUSE);

--- a/src/test/java/domain/game/DeckTest.java
+++ b/src/test/java/domain/game/DeckTest.java
@@ -119,6 +119,18 @@ class DeckTest {
     }
 
     @Test
+    void insertCard_MiddlePosition_InsertsRelativeToTop() {
+        Card bottomCard = new Card(CardType.SKIP);
+        Card topCard = new Card(CardType.ATTACK);
+        Card insertedCard = new Card(CardType.EXPLODING_KITTEN);
+        Deck deck = new Deck(List.of(bottomCard, topCard));
+
+        deck.insertCard(insertedCard, 1);
+
+        assertEquals(List.of(bottomCard, insertedCard, topCard), deck.snapshot());
+    }
+
+    @Test
     void removeCardsByTypeReturnsEmptyListWhenTypeIsAbsent() {
         Card firstCard = createCardWithType(CardType.PLACEHOLDER_CARD);
         Card secondCard = createCardWithType(CardType.DEFUSE);

--- a/src/test/java/domain/game/ExplodingKittenCardControllerTest.java
+++ b/src/test/java/domain/game/ExplodingKittenCardControllerTest.java
@@ -70,6 +70,25 @@ class ExplodingKittenCardControllerTest {
     }
 
     @Test
+    void play_DefuseWithMiddlePosition_ReinsertsKittenAtSelectedPosition() {
+        Player player = new Player("Alice");
+        Card defuse = new Card(CardType.DEFUSE);
+        Card bottomCard = new Card(CardType.SKIP);
+        Card topCard = new Card(CardType.ATTACK);
+        Card explodingKitten = new Card(CardType.EXPLODING_KITTEN);
+        player.addCard(defuse);
+        Deck drawPile = new Deck(List.of(bottomCard, topCard));
+        DiscardPile discardPile = new DiscardPile();
+        ExplodingKittenCardController controller =
+                new ExplodingKittenCardController(drawPile, discardPile);
+
+        boolean defused = controller.play(player, explodingKitten, 1);
+
+        assertTrue(defused);
+        assertEquals(List.of(bottomCard, explodingKitten, topCard), drawPile.snapshot());
+    }
+
+    @Test
     void play_AllButOneCardIsDefuse_RemovesOneDefuseAndKeepsOtherCards() {
         Player player = new Player("Alice");
         Card firstDefuse = new Card(CardType.DEFUSE);

--- a/src/test/java/domain/game/ExplodingKittenCardControllerTest.java
+++ b/src/test/java/domain/game/ExplodingKittenCardControllerTest.java
@@ -21,7 +21,7 @@ class ExplodingKittenCardControllerTest {
         ExplodingKittenCardController controller =
                 new ExplodingKittenCardController(drawPile, discardPile);
 
-        boolean defused = controller.play(player, new Card(CardType.EXPLODING_KITTEN));
+        boolean defused = controller.play(player, new Card(CardType.EXPLODING_KITTEN), 0);
 
         assertFalse(defused);
         assertEquals(0, player.getHandSize());
@@ -42,7 +42,7 @@ class ExplodingKittenCardControllerTest {
         ExplodingKittenCardController controller =
                 new ExplodingKittenCardController(drawPile, discardPile);
 
-        boolean defused = controller.play(player, new Card(CardType.EXPLODING_KITTEN));
+        boolean defused = controller.play(player, new Card(CardType.EXPLODING_KITTEN), 0);
 
         assertFalse(defused);
         assertEquals(List.of(handCard), player.getHandSnapshot());
@@ -61,7 +61,7 @@ class ExplodingKittenCardControllerTest {
         ExplodingKittenCardController controller =
                 new ExplodingKittenCardController(drawPile, discardPile);
 
-        boolean defused = controller.play(player, explodingKitten);
+        boolean defused = controller.play(player, explodingKitten, 0);
 
         assertTrue(defused);
         assertEquals(0, player.getHandSize());
@@ -106,7 +106,7 @@ class ExplodingKittenCardControllerTest {
         ExplodingKittenCardController controller =
                 new ExplodingKittenCardController(drawPile, discardPile);
 
-        boolean defused = controller.play(player, explodingKitten);
+        boolean defused = controller.play(player, explodingKitten, 0);
 
         assertTrue(defused);
         assertEquals(List.of(secondDefuse, catCard), player.getHandSnapshot());
@@ -131,7 +131,7 @@ class ExplodingKittenCardControllerTest {
         ExplodingKittenCardController controller =
                 new ExplodingKittenCardController(drawPile, discardPile);
 
-        boolean defused = controller.play(player, explodingKitten);
+        boolean defused = controller.play(player, explodingKitten, 0);
 
         assertTrue(defused);
         assertEquals(List.of(secondDefuse), player.getHandSnapshot());
@@ -158,7 +158,7 @@ class ExplodingKittenCardControllerTest {
         IllegalArgumentException exception =
                 assertThrows(
                         IllegalArgumentException.class,
-                        () -> controller.play(player, new Card(CardType.DEFUSE)));
+                        () -> controller.play(player, new Card(CardType.DEFUSE), 0));
 
         assertEquals("drawn card must be an exploding kitten", exception.getMessage());
         assertEquals(List.of(defuse), player.getHandSnapshot());
@@ -178,7 +178,7 @@ class ExplodingKittenCardControllerTest {
         player.addCard(new Card(CardType.DEFUSE));           // add defuse at index 1
 
         Card explodingKitten = new Card(CardType.EXPLODING_KITTEN);
-        boolean result = controller.play(player, explodingKitten);
+        boolean result = controller.play(player, explodingKitten, 0);
 
         assertTrue(result);
         assertEquals(1, player.getHandSize()); // placeholder remains after defuse is removed

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -1643,7 +1643,7 @@ public class GameControllerTest {
         EliminatedPlayer record = game.getEliminatedPlayers().get(0);
         assertEquals("Avery", record.getPlayerName());
         assertEquals(explodingKitten, record.getKillingKitten());
-        assertEquals(List.of(remainingCard, secondRemainingCard), record.getVisibleCards());
+        assertEquals(2, record.getFaceDownCardCount());
 
         EasyMock.verify(mockView);
     }

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -1157,7 +1157,7 @@ public class GameControllerTest {
     }
 
     @Test
-    void takeCard_ExplodingKittenWithDefuse_DefusesAndReinsertsKitten() {
+    void takeCard_ExplodingKittenWithDefuse_ReinsertsKittenAtSelectedPosition() {
         Game game = new Game(createDeckForPlayers(2));
         game.setupGame(List.of("Avery", "Jordan"));
         Player currentPlayer = game.getCurrentPlayer();
@@ -1165,11 +1165,16 @@ public class GameControllerTest {
         Card defuse = new Card(CardType.DEFUSE);
         currentPlayer.addCard(defuse);
         clearDrawPile(game.getDrawPile());
+        Card bottomCard = new Card(CardType.SKIP);
+        Card topCard = new Card(CardType.ATTACK);
         Card explodingKitten = new Card(CardType.EXPLODING_KITTEN);
+        game.getDrawPile().addCard(bottomCard);
+        game.getDrawPile().addCard(topCard);
         game.getDrawPile().addCard(explodingKitten);
         GameView mockView = EasyMock.createMock(GameView.class);
         mockView.displayCardDrawn(explodingKitten);
         expectLastCall().once();
+        expect(mockView.promptDefuseInsertionPosition(2)).andReturn(1).once();
         EasyMock.replay(mockView);
         GameController controller = new GameController(game, mockView);
 
@@ -1178,7 +1183,9 @@ public class GameControllerTest {
         assertEquals(explodingKitten, drawnCard);
         assertEquals(0, currentPlayer.getHandSize());
         assertEquals(List.of(defuse), game.getDiscardPile().snapshot());
-        assertEquals(List.of(explodingKitten), game.getDrawPile().snapshot());
+        assertEquals(
+                List.of(bottomCard, explodingKitten, topCard),
+                game.getDrawPile().snapshot());
         assertTrue(game.getPlayers().contains(currentPlayer));
         assertEquals(2, game.getPlayers().size());
         verify(mockView);
@@ -1197,6 +1204,7 @@ public class GameControllerTest {
         GameView mockView = EasyMock.createMock(GameView.class);
         mockView.displayCardDrawn(explodingKitten);
         expectLastCall().once();
+        expect(mockView.promptDefuseInsertionPosition(0)).andReturn(0).once();
         EasyMock.replay(mockView);
         GameController controller = new GameController(game, mockView);
 

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -407,7 +407,7 @@ class GameTest {
     }
 
     @Test
-    void eliminatePlayer_WithExplodingKitten_TracksFaceUpKittenAndRemainingCards() {
+    void eliminatePlayer_WithExplodingKitten_TracksFaceUpKittenAndFaceDownCardCount() {
         Game game = new Game(createDeck(1, 2, 10));
         game.setupGame(List.of("Avery", "Jordan"));
 
@@ -429,8 +429,7 @@ class GameTest {
         EliminatedPlayer record = game.getEliminatedPlayers().get(0);
         assertEquals("Avery", record.getPlayerName());
         assertEquals(killingKitten, record.getKillingKitten());
-        assertEquals(List.of(remainingCard, secondRemainingCard), record.getVisibleCards());
-        assertEquals(2, record.getVisibleCardCount());
+        assertEquals(2, record.getFaceDownCardCount());
     }
 
     @Test

--- a/src/test/java/ui/GameViewTest.java
+++ b/src/test/java/ui/GameViewTest.java
@@ -255,6 +255,16 @@ public class GameViewTest {
     }
 
     @Test
+    void promptDefuseInsertionPosition_OutOfRangeThenValid_ReturnsValidChoice() {
+        GameView view = viewWithInput("-1", "2");
+
+        int position = view.promptDefuseInsertionPosition(3);
+
+        assertEquals(2, position);
+        assertTrue(captured().contains("Choose a position between 0 and 3."));
+    }
+
+    @Test
     void promptTargetPlayer_OutOfRangeThenValid_ReturnsSelectedPlayer() {
         GameView view = viewWithInput("0", "2");
         Player firstPlayer = new Player("Alice");

--- a/src/test/java/ui/GameViewTest.java
+++ b/src/test/java/ui/GameViewTest.java
@@ -380,12 +380,10 @@ public class GameViewTest {
             activePlayer.addCard(new Card(CardType.SKIP));
 
             Card killingKitten = new Card(CardType.EXPLODING_KITTEN);
-            Card visibleCard = new Card(CardType.DEFUSE);
-            Card secondVisibleCard = new Card(CardType.TACOCAT);
             EliminatedPlayer eliminatedPlayer = new EliminatedPlayer(
                     "Avery",
                     killingKitten,
-                    List.of(visibleCard, secondVisibleCard));
+                    2);
 
             view.displayPublicPlayerState(
                     List.of(activePlayer),

--- a/src/test/java/ui/GameViewTest.java
+++ b/src/test/java/ui/GameViewTest.java
@@ -244,6 +244,17 @@ public class GameViewTest {
     }
 
     @Test
+    void promptDefuseInsertionPosition_BottomPosition_ReturnsChoiceAndWarnsOtherPlayers() {
+        GameView view = viewWithInput("3");
+
+        int position = view.promptDefuseInsertionPosition(3);
+
+        assertEquals(3, position);
+        assertTrue(captured().contains("Everyone except the current player: look away now."));
+        assertTrue(captured().contains("0 (top) to 3 (bottom)"));
+    }
+
+    @Test
     void promptTargetPlayer_OutOfRangeThenValid_ReturnsSelectedPlayer() {
         GameView view = viewWithInput("0", "2");
         Player firstPlayer = new Player("Alice");

--- a/src/test/java/ui/GameViewTest.java
+++ b/src/test/java/ui/GameViewTest.java
@@ -367,7 +367,7 @@ public class GameViewTest {
     }
 
     @Test
-    void displayPublicPlayerState_WithActiveAndEliminatedPlayers_PrintsFaceDownAndFaceUpState() {
+    void displayPublicPlayerState_WithEliminatedPlayer_HidesRemainingCardTypes() {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         PrintStream originalOut = System.out;
         System.setOut(new PrintStream(output, true, StandardCharsets.UTF_8));
@@ -395,9 +395,9 @@ public class GameViewTest {
 
             assertTrue(printed.contains("Jordan: 2 face-down card(s)"));
             assertTrue(printed.contains("Avery: eliminated by face-up EXPLODING_KITTEN"));
-            assertTrue(printed.contains("Remaining face-up cards:"));
-            assertTrue(printed.contains("- DEFUSE"));
-            assertTrue(printed.contains("- TACOCAT"));
+            assertTrue(printed.contains("Remaining face-down cards: 2"));
+            assertFalse(printed.contains("DEFUSE"));
+            assertFalse(printed.contains("TACOCAT"));
         } finally {
             System.setOut(originalOut);
         }


### PR DESCRIPTION
## Summary

- show an eliminated player's killing Exploding Kitten face up while exposing only the count of their remaining face-down cards
- let a player with a Defuse secretly choose any Exploding Kitten reinsertion position from the top through the bottom of the draw pile
- keep Defuse as a turn-ending action and avoid prompting players who do not have a Defuse
- update English and German prompt resources plus the Deck, Defuse, and eliminated-player BVA documents

## Implementation

- `EliminatedPlayer` stores a face-down card count instead of the eliminated hand's card types
- `Deck.insertCard` uses positions relative to the top, where `0` is the next draw and `size` is the bottom
- `GameView` tells other players to look away, validates the secret position, and returns only an in-range choice
- `GameController` passes the selected position into `ExplodingKittenCardController` before advancing the turn

