### PR TITLE
extra win condition

### DIFF
--- a/docs/bva/Game.md
+++ b/docs/bva/Game.md
@@ -48,6 +48,16 @@
 | ID | State of the system | Expected output | Implemented? |
 | --- | --- | --- | --- |
 | `GAME-WON-1` | Game has exactly 1 active player after elimination. | Return `true`. | :white_check_mark: |
+| `GAME-WON-2` | More than 1 player remains, and one player has successfully Defused exactly 3 Exploding Kittens. | Return `true`. | :white_check_mark: |
+| `GAME-WON-3` | A player has successfully Defused more than 3 Exploding Kittens. | Continue returning `true`; the earned win does not disappear. | :white_check_mark: |
+
+## Method under test: `Player getWinner()`
+
+| ID | State of the system | Expected output | Implemented? |
+| --- | --- | --- | --- |
+| `GAME-WINNER-1` | One active player remains after elimination. | Return the remaining player. | :white_check_mark: |
+| `GAME-WINNER-2` | Multiple players remain, and one player has successfully Defused at least 3 Exploding Kittens. | Return the player who earned the alternate win. | :white_check_mark: |
+| `GAME-WINNER-3` | Neither win condition has been met. | Throw `IllegalStateException` with message `game does not have a winner`. | :white_check_mark: |
 
 ## Method under test: `public void advanceTurn()`
 

--- a/docs/bva/TakeCard.md
+++ b/docs/bva/TakeCard.md
@@ -42,6 +42,10 @@
         - **State of system**: Current player is `Avery`, next player is `Jordan`, current player hand = [`DEFUSE`], draw pile top card = `EXPLODING_KITTEN`
         - **Expected output**: Returns `EXPLODING_KITTEN`, defuses the kitten, and advances the current player to `Jordan`
 
+    - **TC12: takeCard_ThirdDefusedExplodingKitten_DisplaysCurrentPlayerAsWinner** (:white_check_mark:)
+        - **State of system**: Current player has already successfully Defused 2 Exploding Kittens, has a `DEFUSE`, and draws another `EXPLODING_KITTEN`
+        - **Expected output**: Records the third successful Defuse, displays the current player as the winner, and does not advance to another turn
+
 
 ### Method under test: `public void displayCardDrawn(Card card)` view method
 | Step 1                 | Step 2 | Step 3                                                                                                                                      |

--- a/docs/bva/TerminalGame.md
+++ b/docs/bva/TerminalGame.md
@@ -3,7 +3,8 @@
 ## Feature under test
 
 The terminal entry point constructs the complete deck, prompts for two to four
-players, and repeats playable turns until one active player remains.
+players, and repeats playable turns until one active player remains or a player
+successfully Defuses a third Exploding Kitten.
 
 Per the rulebook, a normal turn permits zero or more card plays and ends with a
 draw. Skip, Super Skip, Reverse, Attack, Targeted Attack, and Draw from Bottom
@@ -18,7 +19,7 @@ can end a turn without the normal top draw.
 | Continuing card | Card type | See the Future; Shuffle; Bury; Swap Top and Bottom; Cat pair |
 | Ending card | Card type | Skip; Super Skip; Reverse; Attack; Targeted Attack; Draw from Bottom |
 | Cat pair input | Two indices and target | matching pair; nonmatching pair; no eligible target |
-| Game state | Active-player count | more than one; exactly one winner |
+| Game state | Win condition | more than one active player with no alternate winner; exactly one active player; player has successfully Defused at least 3 Exploding Kittens |
 
 ## Implemented test cases
 
@@ -35,6 +36,7 @@ can end a turn without the normal top draw.
 | `TERMINAL-9` | `playSelectedCard_Reverse_ReversesDirectionAndEndsTurn` | Reverse changes direction and ends the turn. | :white_check_mark: |
 | `TERMINAL-10` | `runGame_TwoPlayersDrawingUntilExplosion_StopsWithWinner` | The game loops until one winner remains. | :white_check_mark: |
 | `TERMINAL-11` | `main_PassOnlyGame_DisplaysWinner` | The real entry point runs a complete scripted terminal game. | :white_check_mark: |
+| `TERMINAL-12` | `takeCard_ThirdDefusedExplodingKitten_DisplaysCurrentPlayerAsWinner` | The game ends immediately and displays the player who survives a third Exploding Kitten with a Defuse. | :white_check_mark: |
 
 ## Launch
 

--- a/src/main/java/domain/game/Game.java
+++ b/src/main/java/domain/game/Game.java
@@ -2,9 +2,7 @@ package domain.game;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class Game {
     private static final String DRAW_PILE_REQUIRED_MESSAGE = "draw pile must not be null";
@@ -34,7 +32,6 @@ public class Game {
     private int forcedTurns;
     private int direction = 1;
     private final List<EliminatedPlayer> eliminatedPlayers;
-    private final Map<Player, Integer> defusedKittenCounts;
 
     // Open to discussion: making Game final would avoid this warning, but controller tests currently mock it.
     @SuppressFBWarnings(
@@ -51,7 +48,6 @@ public class Game {
         this.forcedTurns = 0;
         this.direction = 1;
         this.eliminatedPlayers = new ArrayList<>();
-        this.defusedKittenCounts = new HashMap<>();
     }
     public void setupGame(List<String> playerNames) {
         if (playerNames == null) {
@@ -84,7 +80,6 @@ public class Game {
         currentPlayerIndex = 0;
         forcedTurns = 0;
         eliminatedPlayers.clear();
-        defusedKittenCounts.clear();
     }
 
     public List<Player> getPlayers() {
@@ -202,11 +197,11 @@ public class Game {
 
     boolean isWon() {
         return players.size() == 1
-                || players.stream().anyMatch(player -> defusedKittenCounts.getOrDefault(player, 0) >= 3);
+                || players.stream().anyMatch(player -> player.getDefusedKittenCount() >= 3);
     }
 
     void recordDefusedKitten(Player player) {
-        defusedKittenCounts.merge(player, 1, Integer::sum);
+        player.recordDefusedKitten();
     }
 
     Player getWinner() {
@@ -214,7 +209,7 @@ public class Game {
             throw new IllegalStateException(NO_WINNER_MESSAGE);
         }
         for (Player player : players) {
-            if (defusedKittenCounts.getOrDefault(player, 0) >= 3) {
+            if (player.getDefusedKittenCount() >= 3) {
                 return player;
             }
         }

--- a/src/main/java/domain/game/Game.java
+++ b/src/main/java/domain/game/Game.java
@@ -18,6 +18,7 @@ public class Game {
             "deck must contain enough exploding kittens for setup";
     private static final String NOT_ENOUGH_STARTING_CARDS_MESSAGE =
             "deck must contain enough non-special cards to deal opening hands";
+    private static final String NO_WINNER_MESSAGE = "game does not have a winner";
     private static final int MIN_PLAYERS = 2;
     private static final int MAX_PLAYERS = 4;
     private static final int OPENING_HAND_SIZE = 5;
@@ -209,6 +210,9 @@ public class Game {
     }
 
     Player getWinner() {
+        if (!isWon()) {
+            throw new IllegalStateException(NO_WINNER_MESSAGE);
+        }
         for (Player player : players) {
             if (defusedKittenCounts.getOrDefault(player, 0) >= 3) {
                 return player;

--- a/src/main/java/domain/game/Game.java
+++ b/src/main/java/domain/game/Game.java
@@ -201,7 +201,7 @@ public class Game {
 
     boolean isWon() {
         return players.size() == 1
-                || players.stream().anyMatch(player -> defusedKittenCounts.getOrDefault(player, 0) == 3);
+                || players.stream().anyMatch(player -> defusedKittenCounts.getOrDefault(player, 0) >= 3);
     }
 
     void recordDefusedKitten(Player player) {

--- a/src/main/java/domain/game/Game.java
+++ b/src/main/java/domain/game/Game.java
@@ -208,6 +208,15 @@ public class Game {
         defusedKittenCounts.merge(player, 1, Integer::sum);
     }
 
+    Player getWinner() {
+        for (Player player : players) {
+            if (defusedKittenCounts.getOrDefault(player, 0) >= 3) {
+                return player;
+            }
+        }
+        return players.get(0);
+    }
+
     int getForcedTurns() {
         return forcedTurns;
     }

--- a/src/main/java/domain/game/Game.java
+++ b/src/main/java/domain/game/Game.java
@@ -2,7 +2,9 @@ package domain.game;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Game {
     private static final String DRAW_PILE_REQUIRED_MESSAGE = "draw pile must not be null";
@@ -31,6 +33,7 @@ public class Game {
     private int forcedTurns;
     private int direction = 1;
     private final List<EliminatedPlayer> eliminatedPlayers;
+    private final Map<Player, Integer> defusedKittenCounts;
 
     // Open to discussion: making Game final would avoid this warning, but controller tests currently mock it.
     @SuppressFBWarnings(
@@ -47,6 +50,7 @@ public class Game {
         this.forcedTurns = 0;
         this.direction = 1;
         this.eliminatedPlayers = new ArrayList<>();
+        this.defusedKittenCounts = new HashMap<>();
     }
     public void setupGame(List<String> playerNames) {
         if (playerNames == null) {
@@ -79,6 +83,7 @@ public class Game {
         currentPlayerIndex = 0;
         forcedTurns = 0;
         eliminatedPlayers.clear();
+        defusedKittenCounts.clear();
     }
 
     public List<Player> getPlayers() {
@@ -195,7 +200,12 @@ public class Game {
     }
 
     boolean isWon() {
-        return players.size() == 1;
+        return players.size() == 1
+                || players.stream().anyMatch(player -> defusedKittenCounts.getOrDefault(player, 0) == 3);
+    }
+
+    void recordDefusedKitten(Player player) {
+        defusedKittenCounts.merge(player, 1, Integer::sum);
     }
 
     int getForcedTurns() {

--- a/src/main/java/domain/game/GameController.java
+++ b/src/main/java/domain/game/GameController.java
@@ -206,12 +206,17 @@ public class GameController {
         boolean defused = explodingKittenController.play(
                 currentPlayer, drawnCard, insertionPosition);
         if (defused) {
+            model.recordDefusedKitten(currentPlayer);
+            if (model.isWon()) {
+                view.displayGameOver(model.getWinner().getName());
+                return;
+            }
             model.advanceTurn();
             return;
         }
         model.eliminatePlayer(currentPlayer, drawnCard);
         if (model.isWon()) {
-            view.displayGameOver(model.getPlayers().get(0).getName());
+            view.displayGameOver(model.getWinner().getName());
         }
     }
 

--- a/src/main/java/domain/game/Player.java
+++ b/src/main/java/domain/game/Player.java
@@ -15,6 +15,7 @@ public final class Player {
 
     private final String name;
     private final List<Card> hand;
+    private int defusedKittenCount;
 
     public Player(String name) {
         if (name == null || name.isBlank()) {
@@ -22,6 +23,7 @@ public final class Player {
         }
         this.name = name;
         this.hand = new ArrayList<>();
+        this.defusedKittenCount = 0;
     }
 
     public String getName() {
@@ -77,6 +79,14 @@ public final class Player {
     long countCardsOfType(CardType type) {
         Objects.requireNonNull(type, "type must not be null");
         return hand.stream().filter(card -> card.getType() == type).count();
+    }
+
+    void recordDefusedKitten() {
+        defusedKittenCount++;
+    }
+
+    int getDefusedKittenCount() {
+        return defusedKittenCount;
     }
 
     public boolean canSubmitCard(int cardIndex) {

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -1216,6 +1216,35 @@ public class GameControllerTest {
     }
 
     @Test
+    void takeCard_ThirdDefusedExplodingKitten_DisplaysCurrentPlayerAsWinner() {
+        Game game = new Game(createDeckForPlayers(2));
+        game.setupGame(List.of("Avery", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        currentPlayer.addCard(new Card(CardType.DEFUSE));
+        game.recordDefusedKitten(currentPlayer);
+        game.recordDefusedKitten(currentPlayer);
+        clearDrawPile(game.getDrawPile());
+        Card explodingKitten = new Card(CardType.EXPLODING_KITTEN);
+        game.getDrawPile().addCard(explodingKitten);
+        GameView mockView = EasyMock.createMock(GameView.class);
+        mockView.displayCardDrawn(explodingKitten);
+        expectLastCall().once();
+        expect(mockView.promptDefuseInsertionPosition(0)).andReturn(0).once();
+        mockView.displayGameOver("Avery");
+        expectLastCall().once();
+        EasyMock.replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.takeCard();
+
+        assertTrue(game.isWon());
+        assertEquals(currentPlayer, game.getWinner());
+        assertEquals(currentPlayer, game.getCurrentPlayer());
+        verify(mockView);
+    }
+
+    @Test
     void playSkip_ValidSkip_ReturnsTrueAndDisplaysMessage() {
         Game mockModel = EasyMock.createMock(Game.class);
         GameView mockView = EasyMock.createMock(GameView.class);

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -175,6 +175,19 @@ class GameTest {
     }
 
     @Test
+    void getWinner_PlayerDefusesThirdExplodingKitten_ReturnsThatPlayer() {
+        Game game = new Game(createDeck(2, 2, 10));
+        game.setupGame(List.of("Avery", "Jordan"));
+        Player alternateWinner = game.getPlayers().get(1);
+
+        game.recordDefusedKitten(alternateWinner);
+        game.recordDefusedKitten(alternateWinner);
+        game.recordDefusedKitten(alternateWinner);
+
+        assertEquals(alternateWinner, game.getWinner());
+    }
+
+    @Test
     void eliminatePlayer_WithThreePlayers_RemovesPlayerAndGameContinues() {
         Game game = new Game(createDeck(3, 3, 15));
         game.setupGame(List.of("Avery", "Jordan", "Casey"));

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -149,6 +149,19 @@ class GameTest {
     }
 
     @Test
+    void isWon_PlayerDefusesThirdExplodingKitten_ReturnsTrue() {
+        Game game = new Game(createDeck(2, 2, 10));
+        game.setupGame(List.of("Avery", "Jordan"));
+        Player player = game.getCurrentPlayer();
+
+        game.recordDefusedKitten(player);
+        game.recordDefusedKitten(player);
+        game.recordDefusedKitten(player);
+
+        assertTrue(game.isWon());
+    }
+
+    @Test
     void eliminatePlayer_WithThreePlayers_RemovesPlayerAndGameContinues() {
         Game game = new Game(createDeck(3, 3, 15));
         game.setupGame(List.of("Avery", "Jordan", "Casey"));

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -162,6 +162,19 @@ class GameTest {
     }
 
     @Test
+    void isWon_PlayerDefusesMoreThanThreeExplodingKittens_RemainsTrue() {
+        Game game = new Game(createDeck(2, 2, 10));
+        game.setupGame(List.of("Avery", "Jordan"));
+        Player player = game.getCurrentPlayer();
+
+        for (int count = 0; count < 4; count++) {
+            game.recordDefusedKitten(player);
+        }
+
+        assertTrue(game.isWon());
+    }
+
+    @Test
     void eliminatePlayer_WithThreePlayers_RemovesPlayerAndGameContinues() {
         Game game = new Game(createDeck(3, 3, 15));
         game.setupGame(List.of("Avery", "Jordan", "Casey"));

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -188,6 +188,17 @@ class GameTest {
     }
 
     @Test
+    void getWinner_BeforeGameIsWon_ThrowsException() {
+        Game game = new Game(createDeck(2, 2, 10));
+        game.setupGame(List.of("Avery", "Jordan"));
+
+        IllegalStateException exception =
+                assertThrows(IllegalStateException.class, game::getWinner);
+
+        assertEquals("game does not have a winner", exception.getMessage());
+    }
+
+    @Test
     void eliminatePlayer_WithThreePlayers_RemovesPlayerAndGameContinues() {
         Game game = new Game(createDeck(3, 3, 15));
         game.setupGame(List.of("Avery", "Jordan", "Casey"));


### PR DESCRIPTION
## Summary

- add the alternate Exploding WildKitten win condition: a player wins immediately after successfully Defusing their third Exploding Kitten
- preserve the normal last-active-player win condition
- identify the correct winner even when multiple players remain
- display the alternate winner immediately and stop turn advancement
- update Game, TakeCard, and terminal-game BVA documentation