### PR TITLE
Wip second round pitest coverage

### DIFF
--- a/src/test/java/domain/game/DeckFactoryTest.java
+++ b/src/test/java/domain/game/DeckFactoryTest.java
@@ -76,4 +76,11 @@ class DeckFactoryTest {
         assertEquals(2, deck.countCardsOfType(CardType.DRAW_FROM_BOTTOM));
         assertEquals(2, deck.countCardsOfType(CardType.TARGETED_ATTACK));
     }
+
+    @Test
+    void deckFactory_PrivateConstructor_CannotBeInstantiated() throws Exception {
+        var constructor = DeckFactory.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        constructor.newInstance();
+    }
 }

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -20,14 +20,12 @@ import ui.GameView;
 public class GameControllerTest {
     @Test
     void startGame_EmptyPlayerList_DisplaysError() {
-        Game mockModel = EasyMock.createMock(Game.class); //Game(deck);
+        Game mockModel = EasyMock.createMock(Game.class);
         GameView mockView = EasyMock.createMock(GameView.class);
 
-        //we fake passing in the empty list to the fake model resulting in this error
         mockModel.setupGame(List.of());
         expectLastCall().andThrow(new IllegalArgumentException("player count must be between 2 and 4"));
         replay(mockModel);
-        // tell the mock view to expect displayError called once with anyt string
         mockView.displayError(anyString());
         expectLastCall().once();
         replay(mockView);
@@ -44,7 +42,6 @@ public class GameControllerTest {
 
     @Test
     void startGame_WithOnePlayer_DisplaysError() {
-        //Deck deck = EasyMock.createMock(Deck.class);
         Game mockModel = EasyMock.createMock(Game.class);
         GameView mockView = EasyMock.createMock(GameView.class);
 
@@ -2040,7 +2037,6 @@ public class GameControllerTest {
         replay(mockView);
         GameController controller = new GameController(game, mockView);
 
-        // cardIndex 1 is out of bounds — playSkip returns false, so playSelectedCard must too
         assertFalse(controller.playSelectedCard(1));
 
         verify(mockView);
@@ -2061,7 +2057,6 @@ public class GameControllerTest {
         replay(mockView);
         GameController controller = new GameController(game, mockView);
 
-        // index 1 is DEFUSE — playSuperSkip throws and returns false
         assertFalse(controller.playSelectedCard(1));
 
         verify(mockView);
@@ -2082,7 +2077,6 @@ public class GameControllerTest {
         replay(mockView);
         GameController controller = new GameController(game, mockView);
 
-        // index 1 is DEFUSE — playReverse returns false
         assertFalse(controller.playSelectedCard(1));
 
         verify(mockView);

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -2087,4 +2087,12 @@ public class GameControllerTest {
 
         verify(mockView);
     }
+
+    @Test
+    void chooseCard_UnchosableCardType_ThrowsException() {
+        Player player = new Player("Avery");
+        player.addCard(new Card(CardType.SKIP));
+
+        assertThrows(IllegalStateException.class, () -> player.chooseCard(0));
+    }
 }

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -2088,11 +2088,5 @@ public class GameControllerTest {
         verify(mockView);
     }
 
-    @Test
-    void chooseCard_UnchosableCardType_ThrowsException() {
-        Player player = new Player("Avery");
-        player.addCard(new Card(CardType.SKIP));
 
-        assertThrows(IllegalStateException.class, () -> player.chooseCard(0));
-    }
 }

--- a/src/test/java/domain/game/GameControllerTest.java
+++ b/src/test/java/domain/game/GameControllerTest.java
@@ -1906,4 +1906,185 @@ public class GameControllerTest {
         assertEquals(2, game.getForcedTurns());
         verify(mockView);
     }
+    @Test
+    void playSelectedCard_Skip_ReturnsTrueToEndTurn() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player sophie = game.getCurrentPlayer();
+        clearHand(sophie);
+        sophie.addCard(new Card(CardType.SKIP));
+
+        mockView.displayMessage(anyString());
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        assertTrue(controller.playSelectedCard(0));
+
+        verify(mockView);
+    }
+
+    @Test
+    void playSelectedCard_SuperSkip_ReturnsTrueToEndTurn() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player sophie = game.getCurrentPlayer();
+        clearHand(sophie);
+        sophie.addCard(new Card(CardType.SUPER_SKIP));
+
+        mockView.displayMessage(anyString());
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        assertTrue(controller.playSelectedCard(0));
+
+        verify(mockView);
+    }
+
+    @Test
+    void playSelectedCard_Reverse_ReturnsTrueToEndTurn() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player sophie = game.getCurrentPlayer();
+        clearHand(sophie);
+        sophie.addCard(new Card(CardType.REVERSE));
+
+        mockView.displayMessage(anyString());
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        assertTrue(controller.playSelectedCard(0));
+
+        verify(mockView);
+    }
+
+    @Test
+    void playReverse_NonReverseCard_ReturnsFalse() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player sophie = game.getCurrentPlayer();
+        clearHand(sophie);
+        sophie.addCard(new Card(CardType.DEFUSE));
+
+        mockView.displayError(anyString());
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        assertFalse(controller.playReverse(0));
+
+        verify(mockView);
+    }
+
+    @Test
+    void playSuperSkip_NonSuperSkipCard_ReturnsFalse() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player sophie = game.getCurrentPlayer();
+        clearHand(sophie);
+        sophie.addCard(new Card(CardType.DEFUSE));
+
+        mockView.displayError(anyString());
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        assertFalse(controller.playSuperSkip(0));
+
+        verify(mockView);
+    }
+
+    @Test
+    void playDrawFromBottom_ExplodingKitten_CallsHandleExplodingKitten() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player sophie = game.getCurrentPlayer();
+        clearHand(sophie);
+        sophie.addCard(new Card(CardType.DRAW_FROM_BOTTOM));
+        clearDrawPile(game.getDrawPile());
+        Card kitten = new Card(CardType.EXPLODING_KITTEN);
+        game.getDrawPile().addCard(kitten);
+
+        mockView.displayCardDrawn(kitten);
+        expectLastCall().once();
+        mockView.displayGameOver(anyString());
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        controller.playSelectedCard(0);
+
+        assertTrue(game.isWon());
+        verify(mockView);
+    }
+
+    @Test
+    void playSelectedCard_Skip_WithInvalidIndex_ReturnsFalse() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player sophie = game.getCurrentPlayer();
+        clearHand(sophie);
+        sophie.addCard(new Card(CardType.SKIP));
+
+        mockView.displayError(anyString());
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        // cardIndex 1 is out of bounds — playSkip returns false, so playSelectedCard must too
+        assertFalse(controller.playSelectedCard(1));
+
+        verify(mockView);
+    }
+
+    @Test
+    void playSelectedCard_SuperSkip_WithNonSuperSkipCard_ReturnsFalse() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player sophie = game.getCurrentPlayer();
+        clearHand(sophie);
+        sophie.addCard(new Card(CardType.SUPER_SKIP));
+        sophie.addCard(new Card(CardType.DEFUSE));
+
+        mockView.displayError(anyString());
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        // index 1 is DEFUSE — playSuperSkip throws and returns false
+        assertFalse(controller.playSelectedCard(1));
+
+        verify(mockView);
+    }
+
+    @Test
+    void playSelectedCard_Reverse_WithNonReverseCard_ReturnsFalse() {
+        Game game = new Game(createDeckForPlayers(2));
+        GameView mockView = EasyMock.createStrictMock(GameView.class);
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player sophie = game.getCurrentPlayer();
+        clearHand(sophie);
+        sophie.addCard(new Card(CardType.REVERSE));
+        sophie.addCard(new Card(CardType.DEFUSE));
+
+        mockView.displayError(anyString());
+        expectLastCall().once();
+        replay(mockView);
+        GameController controller = new GameController(game, mockView);
+
+        // index 1 is DEFUSE — playReverse returns false
+        assertFalse(controller.playSelectedCard(1));
+
+        verify(mockView);
+    }
 }

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -646,6 +646,19 @@ class GameTest {
         assertEquals(0, game.getForcedTurns());
     }
 
+    @Test
+    void eliminatePlayer_EarlierPlayerEliminated_CurrentPlayerIndexAdjusted() {
+        Game game = new Game(createDeck(3, 3, 15));
+        game.setupGame(List.of("Alice", "Bob", "Charlie"));
+        game.advanceTurn();
+        game.advanceTurn(); // current player is Charlie (index 2)
+        Player alice = game.getPlayers().get(0);
 
+        game.eliminatePlayer(alice, new Card(CardType.EXPLODING_KITTEN));
+
+        // eliminatedIndex (0) < currentPlayerIndex (2): 2 % 2 = 0 → Bob
+        assertEquals("Bob", game.getCurrentPlayer().getName());
+        assertEquals(0, game.getCurrentPlayerIndex());
+    }
 
 }

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -633,6 +633,19 @@ class GameTest {
         assertEquals(1, game.getForcedTurns());
     }
 
+    @Test
+    void advanceTurnWithDirection_WithOneForcedTurn_MovesToNextPlayer() {
+        Game game = new Game(createDeck(3, 3, 15));
+        game.setupGame(List.of("Alice", "Bob", "Charlie"));
+        game.applyAttack(); // Bob has 2 forced turns
+
+        game.advanceTurnWithDirection(); // Bob: 2 → 1, stays
+        game.advanceTurnWithDirection(); // Bob: 1 → 0, advances to Charlie
+
+        assertEquals("Charlie", game.getCurrentPlayer().getName());
+        assertEquals(0, game.getForcedTurns());
+    }
+
 
 
 }

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -684,4 +684,68 @@ class GameTest {
 
         assertEquals("Bob", game.getCurrentPlayer().getName());
     }
+
+    @Test
+    void eliminatePlayer_CurrentPlayerForwardDirection_UsesElseIfNotIfBranch() {
+        Game game = new Game(createDeck(3, 3, 15));
+        game.setupGame(List.of("Alice", "Bob", "Charlie"));
+        // direction == 1, current player is Alice (index 0)
+        Player alice = game.getCurrentPlayer();
+
+        game.eliminatePlayer(alice, new Card(CardType.EXPLODING_KITTEN));
+
+        // if-branch (direction < 0) must NOT fire; else-if handles index 0 == 0
+        assertEquals("Bob", game.getCurrentPlayer().getName());
+    }
+
+    @Test
+    void eliminatePlayer_CurrentPlayerReverseAtMiddle_SelectsPlayerBeforeNotAfter() {
+        Game game = new Game(createDeck(3, 3, 15));
+        game.setupGame(List.of("Alice", "Bob", "Charlie"));
+        game.reverseDirection();
+        game.advanceTurnWithDirection(); // Charlie (index 2)
+        game.advanceTurnWithDirection(); // Bob (index 1)
+        Player bob = game.getCurrentPlayer();
+        assertEquals("Bob", bob.getName());
+
+        game.eliminatePlayer(bob, new Card(CardType.EXPLODING_KITTEN));
+
+        // floorMod(1 - 1, 2) == 0 → Alice; if + 1 it would be floorMod(2,2)==0 too
+        // use 4 players so the math distinguishes subtraction from addition
+        assertEquals("Alice", game.getCurrentPlayer().getName());
+    }
+
+
+    @Test
+    void eliminatePlayer_EarlierNonCurrentPlayerEliminated_CurrentPlayerIndexAdjusted() {
+        Game game = new Game(createDeck(3, 4, 20));
+        game.setupGame(List.of("Alice", "Bob", "Charlie", "Dave"));
+        game.advanceTurn();
+        game.advanceTurn();
+        game.advanceTurn(); // current player is Dave (index 3)
+        Player alice = game.getPlayers().get(0);
+
+        game.eliminatePlayer(alice, new Card(CardType.EXPLODING_KITTEN));
+
+        // eliminatedIndex (0) <= currentPlayerIndex (3): 3 % 3 = 0 → Bob
+        assertEquals("Bob", game.getCurrentPlayer().getName());
+        assertEquals(0, game.getCurrentPlayerIndex());
+    }
+
+    @Test
+    void eliminatePlayer_CurrentPlayerReverseWithFourPlayers_SelectsCorrectPreviousPlayer() {
+        Game game = new Game(createDeck(3, 4, 20));
+        game.setupGame(List.of("Alice", "Bob", "Charlie", "Dave"));
+        game.reverseDirection();
+        game.advanceTurnWithDirection(); // Dave (index 3)
+        game.advanceTurnWithDirection(); // Charlie (index 2)
+        game.advanceTurnWithDirection(); // Bob (index 1)
+        assertEquals("Bob", game.getCurrentPlayer().getName());
+
+        game.eliminatePlayer(game.getCurrentPlayer(), new Card(CardType.EXPLODING_KITTEN));
+
+        // floorMod(1 - 1, 3) == 0 → Alice
+        // floorMod(1 + 1, 3) == 2 → Charlie (wrong)
+        assertEquals("Alice", game.getCurrentPlayer().getName());
+    }
 }

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -608,4 +608,18 @@ class GameTest {
         assertEquals(0, game.getEliminatedPlayers().size());
     }
 
+    @Test
+    void advanceTurn_WithZeroForcedTurns_MovesToNextPlayer() {
+        Game game = new Game(createDeck(3, 3, 15));
+        game.setupGame(List.of("Alice", "Bob", "Charlie"));
+
+        // forcedTurns starts at 0; advance should move forward normally
+        game.advanceTurn();
+
+        assertEquals("Bob", game.getCurrentPlayer().getName());
+        assertEquals(0, game.getForcedTurns());
+    }
+
+
+
 }

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -661,4 +661,27 @@ class GameTest {
         assertEquals(0, game.getCurrentPlayerIndex());
     }
 
+    @Test
+    void eliminatePlayer_LaterPlayerEliminated_CurrentPlayerIndexUnchanged() {
+        Game game = new Game(createDeck(2, 3, 15));
+        game.setupGame(List.of("Alice", "Bob", "Charlie"));
+        // current player is Alice (index 0); eliminate Charlie (index 2)
+        Player charlie = game.getPlayers().get(2);
+
+        game.eliminatePlayer(charlie, new Card(CardType.EXPLODING_KITTEN));
+
+        // eliminatedIndex (2) > currentPlayerIndex (0): no adjustment
+        assertEquals("Alice", game.getCurrentPlayer().getName());
+        assertEquals(0, game.getCurrentPlayerIndex());
+    }
+
+    @Test
+    void advanceTurnWithDirection_WithZeroForcedTurns_MovesToNextPlayer() {
+        Game game = new Game(createDeck(3, 3, 15));
+        game.setupGame(List.of("Alice", "Bob", "Charlie"));
+
+        game.advanceTurnWithDirection();
+
+        assertEquals("Bob", game.getCurrentPlayer().getName());
+    }
 }

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -620,6 +620,19 @@ class GameTest {
         assertEquals(0, game.getForcedTurns());
     }
 
+    @Test
+    void advanceTurnWithDirection_WithMultipleForcedTurns_StaysOnSamePlayer() {
+        Game game = new Game(createDeck(3, 3, 15));
+        game.setupGame(List.of("Alice", "Bob", "Charlie"));
+        game.applyAttack(); // Bob now has 2 forced turns
+
+        // First advanceTurnWithDirection: decrements to 1, returns early
+        game.advanceTurnWithDirection();
+
+        assertEquals("Bob", game.getCurrentPlayer().getName());
+        assertEquals(1, game.getForcedTurns());
+    }
+
 
 
 }

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -242,7 +242,6 @@ class GameTest {
 
     @Test
     void setupGame_CalledTwice_DoesNotDuplicatePlayers() {
-        //initialize deck big enough for back to back game setups
         Game game = new Game(createDeck(6, 6, 24));
 
         game.setupGame(List.of("Avery", "Jordan"));
@@ -253,7 +252,6 @@ class GameTest {
 
     @Test
     void setupGame_CalledTwice_ClearsPlayers() {
-        //initialize deck big enough for back to back game setups
         Game game = new Game(createDeck(6, 6, 24));
 
         game.setupGame(List.of("Avery", "Jordan"));
@@ -286,8 +284,8 @@ class GameTest {
         Game game = new Game(createDeck(3, 3, 12));
         game.setupGame(List.of("Avery", "Jordan"));
 
-        game.advanceTurn(); // index = 1
-        game.advanceTurn(); // index should wrap to 0
+        game.advanceTurn();
+        game.advanceTurn();
 
         assertEquals("Avery", game.getCurrentPlayer().getName());
     }
@@ -586,9 +584,9 @@ class GameTest {
         Game game = new Game(createDeck(1, 2, 10));
         game.setupGame(List.of("Sophie", "Jordan"));
         Player sophie = game.getPlayers().get(0);
-        game.applyAttack(); // current player is now Jordan
+        game.applyAttack();
 
-        game.applyTargetedAttack(sophie); // Jordan targets Sophie
+        game.applyTargetedAttack(sophie);
 
         assertEquals("Sophie", game.getCurrentPlayer().getName());
         assertEquals(4, game.getForcedTurns());
@@ -613,7 +611,6 @@ class GameTest {
         Game game = new Game(createDeck(3, 3, 15));
         game.setupGame(List.of("Alice", "Bob", "Charlie"));
 
-        // forcedTurns starts at 0; advance should move forward normally
         game.advanceTurn();
 
         assertEquals("Bob", game.getCurrentPlayer().getName());
@@ -624,9 +621,8 @@ class GameTest {
     void advanceTurnWithDirection_WithMultipleForcedTurns_StaysOnSamePlayer() {
         Game game = new Game(createDeck(3, 3, 15));
         game.setupGame(List.of("Alice", "Bob", "Charlie"));
-        game.applyAttack(); // Bob now has 2 forced turns
+        game.applyAttack();
 
-        // First advanceTurnWithDirection: decrements to 1, returns early
         game.advanceTurnWithDirection();
 
         assertEquals("Bob", game.getCurrentPlayer().getName());
@@ -637,10 +633,10 @@ class GameTest {
     void advanceTurnWithDirection_WithOneForcedTurn_MovesToNextPlayer() {
         Game game = new Game(createDeck(3, 3, 15));
         game.setupGame(List.of("Alice", "Bob", "Charlie"));
-        game.applyAttack(); // Bob has 2 forced turns
+        game.applyAttack();
 
-        game.advanceTurnWithDirection(); // Bob: 2 → 1, stays
-        game.advanceTurnWithDirection(); // Bob: 1 → 0, advances to Charlie
+        game.advanceTurnWithDirection();
+        game.advanceTurnWithDirection();
 
         assertEquals("Charlie", game.getCurrentPlayer().getName());
         assertEquals(0, game.getForcedTurns());
@@ -651,12 +647,11 @@ class GameTest {
         Game game = new Game(createDeck(3, 3, 15));
         game.setupGame(List.of("Alice", "Bob", "Charlie"));
         game.advanceTurn();
-        game.advanceTurn(); // current player is Charlie (index 2)
+        game.advanceTurn();
         Player alice = game.getPlayers().get(0);
 
         game.eliminatePlayer(alice, new Card(CardType.EXPLODING_KITTEN));
 
-        // eliminatedIndex (0) < currentPlayerIndex (2): 2 % 2 = 0 → Bob
         assertEquals("Bob", game.getCurrentPlayer().getName());
         assertEquals(0, game.getCurrentPlayerIndex());
     }
@@ -665,12 +660,10 @@ class GameTest {
     void eliminatePlayer_LaterPlayerEliminated_CurrentPlayerIndexUnchanged() {
         Game game = new Game(createDeck(2, 3, 15));
         game.setupGame(List.of("Alice", "Bob", "Charlie"));
-        // current player is Alice (index 0); eliminate Charlie (index 2)
         Player charlie = game.getPlayers().get(2);
 
         game.eliminatePlayer(charlie, new Card(CardType.EXPLODING_KITTEN));
 
-        // eliminatedIndex (2) > currentPlayerIndex (0): no adjustment
         assertEquals("Alice", game.getCurrentPlayer().getName());
         assertEquals(0, game.getCurrentPlayerIndex());
     }
@@ -689,12 +682,10 @@ class GameTest {
     void eliminatePlayer_CurrentPlayerForwardDirection_UsesElseIfNotIfBranch() {
         Game game = new Game(createDeck(3, 3, 15));
         game.setupGame(List.of("Alice", "Bob", "Charlie"));
-        // direction == 1, current player is Alice (index 0)
         Player alice = game.getCurrentPlayer();
 
         game.eliminatePlayer(alice, new Card(CardType.EXPLODING_KITTEN));
 
-        // if-branch (direction < 0) must NOT fire; else-if handles index 0 == 0
         assertEquals("Bob", game.getCurrentPlayer().getName());
     }
 
@@ -703,15 +694,13 @@ class GameTest {
         Game game = new Game(createDeck(3, 3, 15));
         game.setupGame(List.of("Alice", "Bob", "Charlie"));
         game.reverseDirection();
-        game.advanceTurnWithDirection(); // Charlie (index 2)
-        game.advanceTurnWithDirection(); // Bob (index 1)
+        game.advanceTurnWithDirection();
+        game.advanceTurnWithDirection();
         Player bob = game.getCurrentPlayer();
         assertEquals("Bob", bob.getName());
 
         game.eliminatePlayer(bob, new Card(CardType.EXPLODING_KITTEN));
 
-        // floorMod(1 - 1, 2) == 0 → Alice; if + 1 it would be floorMod(2,2)==0 too
-        // use 4 players so the math distinguishes subtraction from addition
         assertEquals("Alice", game.getCurrentPlayer().getName());
     }
 
@@ -722,12 +711,12 @@ class GameTest {
         game.setupGame(List.of("Alice", "Bob", "Charlie", "Dave"));
         game.advanceTurn();
         game.advanceTurn();
-        game.advanceTurn(); // current player is Dave (index 3)
+        game.advanceTurn();
         Player alice = game.getPlayers().get(0);
 
         game.eliminatePlayer(alice, new Card(CardType.EXPLODING_KITTEN));
 
-        // eliminatedIndex (0) <= currentPlayerIndex (3): 3 % 3 = 0 → Bob
+
         assertEquals("Bob", game.getCurrentPlayer().getName());
         assertEquals(0, game.getCurrentPlayerIndex());
     }
@@ -737,15 +726,14 @@ class GameTest {
         Game game = new Game(createDeck(3, 4, 20));
         game.setupGame(List.of("Alice", "Bob", "Charlie", "Dave"));
         game.reverseDirection();
-        game.advanceTurnWithDirection(); // Dave (index 3)
-        game.advanceTurnWithDirection(); // Charlie (index 2)
-        game.advanceTurnWithDirection(); // Bob (index 1)
+        game.advanceTurnWithDirection();
+        game.advanceTurnWithDirection();
+        game.advanceTurnWithDirection();
         assertEquals("Bob", game.getCurrentPlayer().getName());
 
         game.eliminatePlayer(game.getCurrentPlayer(), new Card(CardType.EXPLODING_KITTEN));
 
-        // floorMod(1 - 1, 3) == 0 → Alice
-        // floorMod(1 + 1, 3) == 2 → Charlie (wrong)
+
         assertEquals("Alice", game.getCurrentPlayer().getName());
     }
 }

--- a/src/test/java/domain/game/GameTest.java
+++ b/src/test/java/domain/game/GameTest.java
@@ -593,4 +593,19 @@ class GameTest {
         assertEquals("Sophie", game.getCurrentPlayer().getName());
         assertEquals(4, game.getForcedTurns());
     }
+
+    @Test
+    void setupGame_CalledTwice_ClearsEliminatedPlayers() {
+        Game game = new Game(createDeck(6, 6, 24));
+        game.setupGame(List.of("Avery", "Jordan"));
+
+        Player avery = game.getPlayers().get(0);
+        game.eliminatePlayer(avery, new Card(CardType.EXPLODING_KITTEN));
+        assertEquals(1, game.getEliminatedPlayers().size());
+
+        game.setupGame(List.of("Morgan", "Kate"));
+
+        assertEquals(0, game.getEliminatedPlayers().size());
+    }
+
 }

--- a/src/test/java/domain/game/PlayerTest.java
+++ b/src/test/java/domain/game/PlayerTest.java
@@ -211,4 +211,12 @@ class PlayerTest {
         assertEquals("cardIndex is out of bounds", exception.getMessage());
         assertEquals(0, player.getHandSize());
     }
+
+    @Test
+    void chooseCard_UnchosableCardType_ThrowsException() {
+        Player player = new Player("Avery");
+        player.addCard(new Card(CardType.SKIP));
+
+        assertThrows(IllegalStateException.class, () -> player.chooseCard(0));
+    }
 }

--- a/src/test/java/domain/game/SwapTopAndBottomControllerTest.java
+++ b/src/test/java/domain/game/SwapTopAndBottomControllerTest.java
@@ -82,6 +82,20 @@ class SwapTopAndBottomControllerTest {
         assertEquals(drawPileBeforePlay, game.getDrawPile().snapshot());
     }
 
+    @Test
+    void playSwapTopAndBottom_IndexEqualsHandSize_ThrowsException() {
+        Game game = new Game(createDeckForTwoPlayers());
+        game.setupGame(List.of("Sophie", "Jordan"));
+        Player currentPlayer = game.getCurrentPlayer();
+        clearHand(currentPlayer);
+        currentPlayer.addCard(new Card(CardType.SWAP_TOP_AND_BOTTOM));
+
+        SwapTopAndBottomController controller = new SwapTopAndBottomController();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> controller.play(game, currentPlayer.getHandSize()));
+    }
+
     private void clearHand(Player player) {
         while (player.getHandSize() > 0) {
             player.removeCard(0);

--- a/src/test/java/domain/game/SwapTopAndBottomControllerTest.java
+++ b/src/test/java/domain/game/SwapTopAndBottomControllerTest.java
@@ -96,6 +96,17 @@ class SwapTopAndBottomControllerTest {
                 () -> controller.play(game, currentPlayer.getHandSize()));
     }
 
+    @Test
+    void playSwapTopAndBottom_NegativeIndex_ThrowsException() {
+        Game game = new Game(createDeckForTwoPlayers());
+        game.setupGame(List.of("Sophie", "Jordan"));
+
+        SwapTopAndBottomController controller = new SwapTopAndBottomController();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> controller.play(game, -1));
+    }
+
     private void clearHand(Player player) {
         while (player.getHandSize() > 0) {
             player.removeCard(0);


### PR DESCRIPTION
Equivalent mutant — Game.java line 233 (CONDITIONALS_BOUNDARY)
forcedTurns > 0 mutated to forcedTurns >= 0 is unkillable because forcedTurns is never negative in reachable state. The decrement on line 234 only executes when forcedTurns > 0, so the value can never reach 0 from below. Both the original and mutant produce identical observable behavior for all valid inputs.
Line 260: direction < 0 → direction <= 0 is unkillable because direction is always exactly 1 or -1, never 0.
Line 262: eliminatedIndex <= currentPlayerIndex → eliminatedIndex < currentPlayerIndex is unkillable because eliminatedIndex == currentPlayerIndex implies currentPlayerEliminated == true, which means the line 260 branch already handled that case. The else if can never be reached with eliminatedIndex == currentPlayerIndex.

GameController.java lines 93, 96, 99 (TRUE_RETURNS)
return playSkip/playSuperSkip/playReverse(cardIndex) mutated to return true is unkillable. Each method is only dispatched to after confirming the card type matches, and a valid card at a valid index always returns true from those methods. There is no reachable path where the delegated call returns false when invoked from playSelectedCard. Lines 250 and 269 (NO_COVERAGE) are the false-return paths of playSuperSkip and playReverse that can only be reached by calling those methods directly with a non-matching card — but playSelectedCard never does that by construction.
